### PR TITLE
docs: Add installation and usage instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,18 +43,23 @@ bash .claude/skills/daida-ai/scripts/setup.sh
 
 ### 方法B: 既存プロジェクトに組み込む
 
-Claude Code は `.claude/skills/<name>/SKILL.md` を検索する。
-このリポジトリの `.claude/skills/daida-ai/` ディレクトリをそのままコピーする。
+スクリプトは `daida_ai` Python パッケージに依存するため、**リポジトリ本体ごとクローン**してから Python パッケージをインストールし、スキルディレクトリを登録する必要がある。
 
 ```bash
-# 一時ディレクトリにクローンしてスキルディレクトリだけコピー
-git clone https://github.com/hawkymisc/daida-ai.git /tmp/daida-ai
-cp -r /tmp/daida-ai/.claude/skills/daida-ai /path/to/your/project/.claude/skills/
+# 1. リポジトリを永続的な場所にクローン
+git clone https://github.com/hawkymisc/daida-ai.git ~/.local/share/daida-ai
 
-# セットアップ（コピー先のプロジェクトルートで実行）
-cd /path/to/your/project
-bash .claude/skills/daida-ai/scripts/setup.sh
+# 2. daida_ai パッケージをプロジェクトの venv にインストール
+#    （先にプロジェクトの venv を activate しておく）
+pip install "~/.local/share/daida-ai[voicevox]"
+
+# 3. スキルディレクトリをプロジェクトに登録
+mkdir -p /path/to/your/project/.claude/skills
+cp -r ~/.local/share/daida-ai/.claude/skills/daida-ai \
+    /path/to/your/project/.claude/skills/
 ```
+
+> **ポイント**: `setup.sh` は `pyproject.toml` のある場所を `PROJECT_ROOT` として自動検出するため、方法Aでない場合は `pip install` で直接インストールする。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -31,39 +31,28 @@ LT登壇を代打してくれる Claude Code Agent Skill。
 - [Claude Code](https://claude.ai/code) がインストール済みであること
 - （音声合成に VOICEVOX を使う場合）[VOICEVOX Engine](https://voicevox.hiroshiba.jp/) が `http://localhost:50021` で起動していること
 
-### 手順
-
-**1. リポジトリをクローンする**
-
-Claude Code の Skill として認識させるには、`~/.claude/skills/` 以下に配置するか、プロジェクト内の `.claude/skills/` に置く必要がある。
-
-```bash
-# プロジェクト内に配置する場合（推奨）
-cd /path/to/your/project
-git clone https://github.com/hawkymisc/daida-ai.git .claude/skills/daida-ai-repo
-
-# または、グローバルに使いたい場合
-git clone https://github.com/hawkymisc/daida-ai.git ~/.claude/skills/daida-ai-repo
-```
-
-> **ポイント**: Claude Code は `.claude/skills/<name>/SKILL.md` を自動検出してスキルとして登録する。
-
-**2. Python依存パッケージをインストールする**
-
-```bash
-cd .claude/skills/daida-ai-repo   # または ~/.claude/skills/daida-ai-repo
-bash .claude/skills/daida-ai/scripts/setup.sh
-```
-
-setup.sh は `.venv/` を作成し、必要なパッケージ（python-pptx, edge-tts, pydub 等）をインストールする。
-
-### このリポジトリ自体をプロジェクトとして使う場合
-
-リポジトリのルートで作業する場合はセットアップがシンプル:
+### 方法A: このリポジトリをそのまま使う（最もシンプル）
 
 ```bash
 git clone https://github.com/hawkymisc/daida-ai.git
 cd daida-ai
+bash .claude/skills/daida-ai/scripts/setup.sh
+```
+
+`daida-ai/` を Claude Code のプロジェクトルートとして開けば、`.claude/skills/daida-ai/SKILL.md` が自動検出されてスキルが有効になる。
+
+### 方法B: 既存プロジェクトに組み込む
+
+Claude Code は `.claude/skills/<name>/SKILL.md` を検索する。
+このリポジトリの `.claude/skills/daida-ai/` ディレクトリをそのままコピーする。
+
+```bash
+# 一時ディレクトリにクローンしてスキルディレクトリだけコピー
+git clone https://github.com/hawkymisc/daida-ai.git /tmp/daida-ai
+cp -r /tmp/daida-ai/.claude/skills/daida-ai /path/to/your/project/.claude/skills/
+
+# セットアップ（コピー先のプロジェクトルートで実行）
+cd /path/to/your/project
 bash .claude/skills/daida-ai/scripts/setup.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,112 @@
 # 代打AI
 
-LT登壇を代打してくれるAgent Skills.
+LT登壇を代打してくれる Claude Code Agent Skill。
 
+テーマを伝えるだけで、アウトライン → スライド → トークスクリプト → 音声ナレーション付きPPTXまで自動生成する。
 
 ## 機能概要
 
-1. 登壇テーマを入力したら、発表のアウトラインをMarkdownで出力・保存する
-2. 当該Markdownに基づき、スライド資料を作成する
-  - スライド資料はPowerPointで作成する
-  - 事前に定義されたスライドテンプレートのデザインに従い作成する
-  - スライドは白紙からではなく、スライドレイアウトを選択して作成する
-  - スライドタイトルやテキスト本文はアウトライン表示で確認できるように設定する
-3. スライド資料のnote欄にトークスクリプト(台本)を記入する
-  - スクリプトは、カジュアル、キーノートなど複数のスタイルで文体を選べる
-4. トークスクリプトを読み上げた音声を合成する
-5. 上記音声合成をスライドに埋め込む
+1. テーマからMarkdownアウトラインを生成する
+2. アウトラインをスライド仕様JSON（レイアウト・内容・台本）に充実化する
+3. JSONからPPTXスライドを生成する（tech / casual / formal テンプレート対応）
+4. スピーカーノート（台本）を文体指定で再生成できる
+5. トークスクリプトを音声合成してPPTXに埋め込む（edge-tts / VOICEVOX 対応）
 
 ## 対応フォーマット
 
-pptx および odp(Open Document Presentation)
+- PPTX（PowerPoint / LibreOffice Impress）
+- ODP（LibreOffice インストール時のみ）
+
+## サンプル
+
+`samples/presentation.pptx` — 代打AI自身を使って生成した15分LT資料（20スライド）
+
+---
+
+## インストール
+
+### 前提条件
+
+- Python 3.11 以上
+- [Claude Code](https://claude.ai/code) がインストール済みであること
+- （音声合成に VOICEVOX を使う場合）[VOICEVOX Engine](https://voicevox.hiroshiba.jp/) が `http://localhost:50021` で起動していること
+
+### 手順
+
+**1. リポジトリをクローンする**
+
+Claude Code の Skill として認識させるには、`~/.claude/skills/` 以下に配置するか、プロジェクト内の `.claude/skills/` に置く必要がある。
+
+```bash
+# プロジェクト内に配置する場合（推奨）
+cd /path/to/your/project
+git clone https://github.com/hawkymisc/daida-ai.git .claude/skills/daida-ai-repo
+
+# または、グローバルに使いたい場合
+git clone https://github.com/hawkymisc/daida-ai.git ~/.claude/skills/daida-ai-repo
+```
+
+> **ポイント**: Claude Code は `.claude/skills/<name>/SKILL.md` を自動検出してスキルとして登録する。
+
+**2. Python依存パッケージをインストールする**
+
+```bash
+cd .claude/skills/daida-ai-repo   # または ~/.claude/skills/daida-ai-repo
+bash .claude/skills/daida-ai/scripts/setup.sh
+```
+
+setup.sh は `.venv/` を作成し、必要なパッケージ（python-pptx, edge-tts, pydub 等）をインストールする。
+
+### このリポジトリ自体をプロジェクトとして使う場合
+
+リポジトリのルートで作業する場合はセットアップがシンプル:
+
+```bash
+git clone https://github.com/hawkymisc/daida-ai.git
+cd daida-ai
+bash .claude/skills/daida-ai/scripts/setup.sh
+```
+
+---
+
+## 使い方
+
+セットアップ後、プロジェクトのディレクトリで Claude Code を起動して:
+
+```
+/daida-ai テーマを入力してください
+```
+
+または自然言語で:
+
+```
+LT資料を作りたい。テーマは「Rustの所有権をRubyistに説明する」、5分、社内勉強会向け
+```
+
+Claudeが対話的にヒアリングしながらステップを進める。
+
+### ステップの流れ
+
+```
+Step 1   : アウトライン生成（Claude がMarkdown生成）
+Step 1.5 : コンテンツ充実化（Claude がスライド仕様JSONを生成）
+Step 2   : PPTX生成（python-pptxでスライドファイルを出力）
+Step 3   : トークスクリプト更新（任意・文体指定可）
+Step 4   : 音声合成（edge-tts または VOICEVOX）
+Step 5   : 音声埋め込み（PPTXにMP3を埋め込む）
+```
+
+出力はデフォルトで `./output/` に保存される。
+
+---
+
+## 開発
+
+```bash
+# テスト実行
+source .venv/bin/activate
+pytest tests/
+
+# テンプレートPPTX再生成
+python .claude/skills/daida-ai/scripts/create_templates.py
+```

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ LT登壇を代打してくれる Claude Code Agent Skill。
 - [Claude Code](https://claude.ai/code) がインストール済みであること
 - （音声合成に VOICEVOX を使う場合）[VOICEVOX Engine](https://voicevox.hiroshiba.jp/) が `http://localhost:50021` で起動していること
 
-### 方法A: このリポジトリをそのまま使う（最もシンプル）
+### セットアップ手順
 
 ```bash
 git clone https://github.com/hawkymisc/daida-ai.git
@@ -41,25 +41,7 @@ bash .claude/skills/daida-ai/scripts/setup.sh
 
 `daida-ai/` を Claude Code のプロジェクトルートとして開けば、`.claude/skills/daida-ai/SKILL.md` が自動検出されてスキルが有効になる。
 
-### 方法B: 既存プロジェクトに組み込む
-
-スクリプトは `daida_ai` Python パッケージに依存するため、**リポジトリ本体ごとクローン**してから Python パッケージをインストールし、スキルディレクトリを登録する必要がある。
-
-```bash
-# 1. リポジトリを永続的な場所にクローン
-git clone https://github.com/hawkymisc/daida-ai.git ~/.local/share/daida-ai
-
-# 2. daida_ai パッケージをプロジェクトの venv にインストール
-#    （先にプロジェクトの venv を activate しておく）
-pip install "~/.local/share/daida-ai[voicevox]"
-
-# 3. スキルディレクトリをプロジェクトに登録
-mkdir -p /path/to/your/project/.claude/skills
-cp -r ~/.local/share/daida-ai/.claude/skills/daida-ai \
-    /path/to/your/project/.claude/skills/
-```
-
-> **ポイント**: `setup.sh` は `pyproject.toml` のある場所を `PROJECT_ROOT` として自動検出するため、方法Aでない場合は `pip install` で直接インストールする。
+> **別プロジェクトへの組み込みについて**: `setup.sh` はリポジトリルートに `pyproject.toml` があることを前提とするため、スキルディレクトリだけを別プロジェクトにコピーしても動作しない。現時点ではリポジトリをそのまま使う構成を推奨。
 
 ---
 


### PR DESCRIPTION
## Summary
- クローン先（`.claude/skills/` への配置）の説明を追加
- `setup.sh` によるPython環境構築手順を追加
- Claude Codeからの呼び出し方（`/daida-ai`）を追加
- ステップ一覧・開発用コマンドを追加

## Test plan
- [ ] READMEの手順通りにセットアップして動作確認できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)