### PR TITLE
fix: Use GitHub source in marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,10 @@
   "plugins": [
     {
       "name": "daida-ai",
-      "source": ".",
+      "source": {
+        "source": "github",
+        "repo": "hawkymisc/daida-ai"
+      },
       "description": "LTプレゼン自動生成 — テーマからスライド・音声ナレーション付きPPTXまで一括対応",
       "version": "0.1.0",
       "author": {


### PR DESCRIPTION
## Summary
- marketplace.json の `source: "."` が Claude Code のスキーマバリデーションで `Invalid input` エラー
- 相対パス `"."` → GitHub source `{"source": "github", "repo": "hawkymisc/daida-ai"}` に変更
- `/plugin marketplace add hawkymisc/daida-ai` でのインストールが可能になる

## Test plan
- [ ] `/plugin marketplace add hawkymisc/daida-ai` が成功する
- [ ] `/plugin install daida-ai@hawkymisc-daida-ai` が成功する

🤖 Generated with [Claude Code](https://claude.com/claude-code)