### PR TITLE
fix: Explicit package discovery for plugin cache install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ dev = [
     "httpx>=0.27.0",
 ]
 
+[tool.setuptools.packages.find]
+include = ["daida_ai*"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"


### PR DESCRIPTION
## Summary
- プラグインキャッシュ環境で `pip install -e .` が失敗する問題を修正
- `skills/`, `samples/`, `daida_ai/` の3つが flat-layout auto-discovery で検出されビルド拒否
- `[tool.setuptools.packages.find]` で `daida_ai*` のみを明示的に include

## Test plan
- [x] `pip install -e .[voicevox]` が成功
- [x] 全86テスト通過
- [ ] プラグインキャッシュからの setup.sh 実行テスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)