### PR TITLE
feat: Auto-slideshow with full auto-advance and audio auto-play

### DIFF
--- a/daida_ai/lib/slideshow.py
+++ b/daida_ai/lib/slideshow.py
@@ -35,6 +35,10 @@ _MPEG2_L3_BITRATE = {
 
 _DEFAULT_UNMEASURABLE_DURATION_MS = 30000
 
+# ECMA-376 CT_Slide 子要素の正規順序
+# cSld, clrMapOvr?, transition?, timing?, hf?, extLst?
+_CT_SLIDE_ORDER = ["cSld", "clrMapOvr", "transition", "timing", "hf", "extLst"]
+
 
 def configure_slideshow(
     input_path: Path,
@@ -76,6 +80,32 @@ def configure_slideshow(
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     prs.save(str(output_path))
+
+
+def _insert_slide_child(slide_elem: etree._Element, new_elem: etree._Element) -> None:
+    """CT_Slideのスキーマ順序を守って子要素を挿入する。
+
+    ECMA-376 CT_Slide: cSld, clrMapOvr?, transition?, timing?, hf?, extLst?
+    new_elemのタグ名から正しい挿入位置を算出し、後続要素の直前にinsertする。
+    """
+    new_local = etree.QName(new_elem).localname
+    if new_local not in _CT_SLIDE_ORDER:
+        slide_elem.append(new_elem)
+        return
+
+    new_order = _CT_SLIDE_ORDER.index(new_local)
+
+    # 自分より後ろの要素を探し、その直前に挿入する
+    for child in slide_elem:
+        child_local = etree.QName(child).localname
+        if child_local in _CT_SLIDE_ORDER:
+            child_order = _CT_SLIDE_ORDER.index(child_local)
+            if child_order > new_order:
+                child.addprevious(new_elem)
+                return
+
+    # 後続要素がなければ末尾に追加
+    slide_elem.append(new_elem)
 
 
 def _get_audio_duration_ms(slide) -> int:
@@ -160,7 +190,8 @@ def _set_auto_advance(slide, advance_ms: int) -> None:
     trans = slide_elem.find(f"{{{_P_NS}}}transition")
 
     if trans is None:
-        trans = etree.SubElement(slide_elem, f"{{{_P_NS}}}transition")
+        trans = etree.Element(f"{{{_P_NS}}}transition")
+        _insert_slide_child(slide_elem, trans)
 
     trans.set("advClick", "0")
     trans.set("advTm", str(advance_ms))
@@ -190,7 +221,7 @@ def _add_auto_play_animation(slide) -> None:
     else:
         # timing要素がない場合は新規作成
         timing_elem = _build_timing_xml(audio_shape_ids)
-        slide_elem.append(timing_elem)
+        _insert_slide_child(slide_elem, timing_elem)
 
 
 def _merge_audio_into_timing(

--- a/daida_ai/lib/slideshow.py
+++ b/daida_ai/lib/slideshow.py
@@ -33,12 +33,16 @@ _MPEG2_L3_BITRATE = {
 }
 
 
+_DEFAULT_UNMEASURABLE_DURATION_MS = 30000
+
+
 def configure_slideshow(
     input_path: Path,
     output_path: Path,
     *,
     silent_duration_ms: int = 3000,
     audio_buffer_ms: int = 1000,
+    unmeasurable_duration_ms: int = _DEFAULT_UNMEASURABLE_DURATION_MS,
 ) -> None:
     """PPTXにスライドショー自動再生設定を追加する。
 
@@ -47,14 +51,20 @@ def configure_slideshow(
         output_path: 出力PPTXファイルパス
         silent_duration_ms: 音声なしスライドの表示時間（ミリ秒）
         audio_buffer_ms: 音声付きスライドの再生完了後の余白（ミリ秒）
+        unmeasurable_duration_ms: デュレーション計測不能時のフォールバック（ミリ秒）
     """
     prs = Presentation(str(input_path))
 
     for slide in prs.slides:
+        has_audio_shapes = bool(_find_audio_shape_ids(slide))
         audio_duration = _get_audio_duration_ms(slide)
 
-        if audio_duration > 0:
-            advance_ms = audio_duration + audio_buffer_ms
+        if has_audio_shapes:
+            if audio_duration > 0:
+                advance_ms = audio_duration + audio_buffer_ms
+            else:
+                # 外部リンク/非MP3など計測不能 → フォールバック
+                advance_ms = unmeasurable_duration_ms + audio_buffer_ms
             _add_auto_play_animation(slide)
         else:
             advance_ms = silent_duration_ms
@@ -98,7 +108,7 @@ def _estimate_mp3_duration_ms(data: bytes) -> int:
     """MP3バイナリからデュレーションをミリ秒で推定する。
 
     pydub依存を避け、ファイルサイズとビットレートから概算する。
-    精度は実用上十分（±数秒）。
+    MP3フレームヘッダが見つからない場合（AAC/WAV等）は0を返す。
     """
     if len(data) < 10:
         return 0
@@ -133,9 +143,8 @@ def _estimate_mp3_duration_ms(data: bytes) -> int:
             return max(int(duration_s * 1000), 1)
         offset += 1
 
-    # フレームヘッダが見つからない場合、64kbps仮定で概算（MPEG-2寄り）
-    duration_s = (len(data) * 8) / (64 * 1000)
-    return max(int(duration_s * 1000), 1)
+    # MP3フレームヘッダが見つからない（AAC/WAV等）→ 計測不能
+    return 0
 
 
 def _set_auto_advance(slide, advance_ms: int) -> None:

--- a/daida_ai/lib/slideshow.py
+++ b/daida_ai/lib/slideshow.py
@@ -17,11 +17,19 @@ _R_NS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
 _nsmap = {"p": _P_NS, "a": _A_NS, "r": _R_NS}
 
 # MP3フレームベースの簡易デュレーション推定用
-_MP3_BITRATE_TABLE = {
+# MPEG-1 Layer III ビットレートテーブル (kbps)
+_MPEG1_L3_BITRATE = {
     0b0001: 32, 0b0010: 40, 0b0011: 48, 0b0100: 56,
     0b0101: 64, 0b0110: 80, 0b0111: 96, 0b1000: 112,
     0b1001: 128, 0b1010: 160, 0b1011: 192, 0b1100: 224,
     0b1101: 256, 0b1110: 320,
+}
+# MPEG-2/2.5 Layer III ビットレートテーブル (kbps)
+_MPEG2_L3_BITRATE = {
+    0b0001: 8, 0b0010: 16, 0b0011: 24, 0b0100: 32,
+    0b0101: 40, 0b0110: 48, 0b0111: 56, 0b1000: 64,
+    0b1001: 80, 0b1010: 96, 0b1011: 112, 0b1100: 128,
+    0b1101: 144, 0b1110: 160,
 }
 
 
@@ -71,7 +79,12 @@ def _get_audio_duration_ms(slide) -> int:
 
     max_duration = 0
     for rel in media_rels:
-        audio_blob = rel.target_part.blob
+        if rel.is_external:
+            continue
+        try:
+            audio_blob = rel.target_part.blob
+        except Exception:
+            continue
         duration = _estimate_mp3_duration_ms(audio_blob)
         if duration > max_duration:
             max_duration = duration
@@ -103,15 +116,22 @@ def _estimate_mp3_duration_ms(data: bytes) -> int:
     # 最初のフレームヘッダを探す
     while offset < len(data) - 4:
         if data[offset] == 0xFF and (data[offset + 1] & 0xE0) == 0xE0:
+            # MPEGバージョン判定: ビット4-3 of byte1
+            # 11=MPEG1, 10=MPEG2, 00=MPEG2.5
+            mpeg_version_bits = (data[offset + 1] >> 3) & 0x03
+            is_mpeg1 = mpeg_version_bits == 0b11
+            bitrate_table = _MPEG1_L3_BITRATE if is_mpeg1 else _MPEG2_L3_BITRATE
+            default_bitrate = 128 if is_mpeg1 else 64
+
             bitrate_idx = (data[offset + 2] >> 4) & 0x0F
-            bitrate_kbps = _MP3_BITRATE_TABLE.get(bitrate_idx, 128)
+            bitrate_kbps = bitrate_table.get(bitrate_idx, default_bitrate)
             audio_bytes = len(data) - offset
             duration_s = (audio_bytes * 8) / (bitrate_kbps * 1000)
             return max(int(duration_s * 1000), 1)
         offset += 1
 
-    # フレームヘッダが見つからない場合、128kbps仮定で概算
-    duration_s = (len(data) * 8) / (128 * 1000)
+    # フレームヘッダが見つからない場合、64kbps仮定で概算（MPEG-2寄り）
+    duration_s = (len(data) * 8) / (64 * 1000)
     return max(int(duration_s * 1000), 1)
 
 

--- a/daida_ai/lib/slideshow.py
+++ b/daida_ai/lib/slideshow.py
@@ -69,9 +69,9 @@ def _get_audio_duration_ms(slide) -> int:
     """スライドに埋め込まれた音声のデュレーションを推定する（ミリ秒）。
 
     音声がない場合は0を返す。
-    複数の音声トラックがある場合は最長のデュレーションを返す。
-    OPCリレーションシップからメディアパーツを取得し、
-    MP3バイナリからデュレーションを推定する。
+    複数の音声トラックがある場合は最長のデュレーションを返す
+    （audioノードはdelay="0"で同時再生されるため、maxが正しい）。
+    RT.MEDIAにはビデオも含まれるため、content_typeでaudioのみフィルタする。
     """
     media_rels = [r for r in slide.part.rels.values() if r.reltype == RT.MEDIA]
     if not media_rels:
@@ -82,10 +82,13 @@ def _get_audio_duration_ms(slide) -> int:
         if rel.is_external:
             continue
         try:
-            audio_blob = rel.target_part.blob
+            part = rel.target_part
         except Exception:
             continue
-        duration = _estimate_mp3_duration_ms(audio_blob)
+        # ビデオ等の非音声メディアを除外
+        if not part.content_type.startswith("audio/"):
+            continue
+        duration = _estimate_mp3_duration_ms(part.blob)
         if duration > max_duration:
             max_duration = duration
     return max_duration

--- a/daida_ai/lib/slideshow.py
+++ b/daida_ai/lib/slideshow.py
@@ -1,0 +1,226 @@
+"""スライドショー自動再生設定
+
+PPTXにauto-advance transition と 音声auto-play animation を設定し、
+スライドショー開始から終了まで完全自動で走るようにする。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from lxml import etree
+from pptx import Presentation
+from pptx.opc.package import RT
+
+_P_NS = "http://schemas.openxmlformats.org/presentationml/2006/main"
+_A_NS = "http://schemas.openxmlformats.org/drawingml/2006/main"
+_R_NS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+_nsmap = {"p": _P_NS, "a": _A_NS, "r": _R_NS}
+
+# MP3フレームベースの簡易デュレーション推定用
+_MP3_BITRATE_TABLE = {
+    0b0001: 32, 0b0010: 40, 0b0011: 48, 0b0100: 56,
+    0b0101: 64, 0b0110: 80, 0b0111: 96, 0b1000: 112,
+    0b1001: 128, 0b1010: 160, 0b1011: 192, 0b1100: 224,
+    0b1101: 256, 0b1110: 320,
+}
+
+
+def configure_slideshow(
+    input_path: Path,
+    output_path: Path,
+    *,
+    silent_duration_ms: int = 3000,
+    audio_buffer_ms: int = 1000,
+) -> None:
+    """PPTXにスライドショー自動再生設定を追加する。
+
+    Args:
+        input_path: 入力PPTXファイルパス
+        output_path: 出力PPTXファイルパス
+        silent_duration_ms: 音声なしスライドの表示時間（ミリ秒）
+        audio_buffer_ms: 音声付きスライドの再生完了後の余白（ミリ秒）
+    """
+    prs = Presentation(str(input_path))
+
+    for slide in prs.slides:
+        audio_duration = _get_audio_duration_ms(slide)
+
+        if audio_duration > 0:
+            advance_ms = audio_duration + audio_buffer_ms
+            _add_auto_play_animation(slide)
+        else:
+            advance_ms = silent_duration_ms
+
+        _set_auto_advance(slide, advance_ms)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    prs.save(str(output_path))
+
+
+def _get_audio_duration_ms(slide) -> int:
+    """スライドに埋め込まれた音声のデュレーションを推定する（ミリ秒）。
+
+    音声がない場合は0を返す。
+    OPCリレーションシップからメディアパーツを取得し、
+    MP3バイナリからデュレーションを推定する。
+    """
+    media_rels = [r for r in slide.part.rels.values() if r.reltype == RT.MEDIA]
+    if not media_rels:
+        return 0
+
+    # 最初のメディアリレーションシップの音声データを取得
+    media_part = media_rels[0].target_part
+    audio_blob = media_part.blob
+    return _estimate_mp3_duration_ms(audio_blob)
+
+
+def _estimate_mp3_duration_ms(data: bytes) -> int:
+    """MP3バイナリからデュレーションをミリ秒で推定する。
+
+    pydub依存を避け、ファイルサイズとビットレートから概算する。
+    精度は実用上十分（±数秒）。
+    """
+    if len(data) < 10:
+        return 0
+
+    offset = 0
+    # ID3タグをスキップ
+    if data[:3] == b"ID3":
+        if len(data) < 10:
+            return 0
+        size = (
+            (data[6] & 0x7F) << 21
+            | (data[7] & 0x7F) << 14
+            | (data[8] & 0x7F) << 7
+            | (data[9] & 0x7F)
+        )
+        offset = 10 + size
+
+    # 最初のフレームヘッダを探す
+    while offset < len(data) - 4:
+        if data[offset] == 0xFF and (data[offset + 1] & 0xE0) == 0xE0:
+            bitrate_idx = (data[offset + 2] >> 4) & 0x0F
+            bitrate_kbps = _MP3_BITRATE_TABLE.get(bitrate_idx, 128)
+            audio_bytes = len(data) - offset
+            duration_s = (audio_bytes * 8) / (bitrate_kbps * 1000)
+            return max(int(duration_s * 1000), 1)
+        offset += 1
+
+    # フレームヘッダが見つからない場合、128kbps仮定で概算
+    duration_s = (len(data) * 8) / (128 * 1000)
+    return max(int(duration_s * 1000), 1)
+
+
+def _set_auto_advance(slide, advance_ms: int) -> None:
+    """スライドに自動ページ送りを設定する。
+
+    既存のtransition要素があれば属性を更新、なければ追加する。
+    advClick="0" でクリックを無効化し、advTm でミリ秒指定。
+    """
+    slide_elem = slide.element
+    trans = slide_elem.find(f"{{{_P_NS}}}transition")
+
+    if trans is None:
+        trans = etree.SubElement(slide_elem, f"{{{_P_NS}}}transition")
+
+    trans.set("advClick", "0")
+    trans.set("advTm", str(advance_ms))
+
+
+def _add_auto_play_animation(slide) -> None:
+    """スライドの音声シェイプに自動再生アニメーションを設定する。
+
+    PowerPointのアニメーション構造:
+    p:timing > p:tnLst > p:par (tmRoot) > p:childTnLst > p:seq (mainSeq) >
+    p:cTn > p:childTnLst > p:par > p:cTn > p:childTnLst > p:par > p:cTn >
+    p:childTnLst > p:audio > p:cMediaNode > p:cTn + p:tgtEl
+    """
+    # 音声シェイプのIDを取得
+    audio_shape_id = _find_audio_shape_id(slide)
+    if audio_shape_id is None:
+        return
+
+    # 既存のtiming要素を削除して再構築
+    slide_elem = slide.element
+    existing_timing = slide_elem.find(f"{{{_P_NS}}}timing")
+    if existing_timing is not None:
+        slide_elem.remove(existing_timing)
+
+    timing_xml = f"""<p:timing xmlns:p="{_P_NS}">
+  <p:tnLst>
+    <p:par>
+      <p:cTn id="1" dur="indefinite" restart="never" nodeType="tmRoot">
+        <p:childTnLst>
+          <p:seq concurrent="1" nextAc="seek">
+            <p:cTn id="2" dur="indefinite" nodeType="mainSeq">
+              <p:childTnLst>
+                <p:par>
+                  <p:cTn id="3" fill="hold">
+                    <p:stCondLst>
+                      <p:cond delay="0"/>
+                    </p:stCondLst>
+                    <p:childTnLst>
+                      <p:par>
+                        <p:cTn id="4" fill="hold">
+                          <p:stCondLst>
+                            <p:cond delay="0"/>
+                          </p:stCondLst>
+                          <p:childTnLst>
+                            <p:audio>
+                              <p:cMediaNode>
+                                <p:cTn id="5" fill="hold" display="0">
+                                  <p:stCondLst>
+                                    <p:cond delay="0"/>
+                                  </p:stCondLst>
+                                </p:cTn>
+                                <p:tgtEl>
+                                  <p:spTgt spid="{audio_shape_id}"/>
+                                </p:tgtEl>
+                              </p:cMediaNode>
+                            </p:audio>
+                          </p:childTnLst>
+                        </p:cTn>
+                      </p:par>
+                    </p:childTnLst>
+                  </p:cTn>
+                </p:par>
+              </p:childTnLst>
+            </p:cTn>
+            <p:prevCondLst>
+              <p:cond evt="onPrev" delay="0">
+                <p:tgtEl><p:sldTgt/></p:tgtEl>
+              </p:cond>
+            </p:prevCondLst>
+            <p:nextCondLst>
+              <p:cond evt="onNext" delay="0">
+                <p:tgtEl><p:sldTgt/></p:tgtEl>
+              </p:cond>
+            </p:nextCondLst>
+          </p:seq>
+        </p:childTnLst>
+      </p:cTn>
+    </p:par>
+  </p:tnLst>
+</p:timing>"""
+
+    timing_elem = etree.fromstring(timing_xml)
+    slide_elem.append(timing_elem)
+
+
+def _find_audio_shape_id(slide) -> int | None:
+    """スライドから音声シェイプのIDを取得する。
+
+    a:audioFile要素を持つp:pic要素のcNvPr idを返す。
+    """
+    slide_elem = slide.element
+    # audioFile要素を持つnvPrを探す
+    for audio_file in slide_elem.iter(f"{{{_A_NS}}}audioFile"):
+        # audioFile → nvPr → nvPicPr → cNvPr
+        nv_pr = audio_file.getparent()
+        if nv_pr is not None:
+            nv_pic_pr = nv_pr.getparent()
+            if nv_pic_pr is not None:
+                c_nv_pr = nv_pic_pr.find(f"{{{_P_NS}}}cNvPr")
+                if c_nv_pr is not None:
+                    return int(c_nv_pr.get("id"))
+    return None

--- a/daida_ai/lib/slideshow.py
+++ b/daida_ai/lib/slideshow.py
@@ -61,6 +61,7 @@ def _get_audio_duration_ms(slide) -> int:
     """スライドに埋め込まれた音声のデュレーションを推定する（ミリ秒）。
 
     音声がない場合は0を返す。
+    複数の音声トラックがある場合は最長のデュレーションを返す。
     OPCリレーションシップからメディアパーツを取得し、
     MP3バイナリからデュレーションを推定する。
     """
@@ -68,10 +69,13 @@ def _get_audio_duration_ms(slide) -> int:
     if not media_rels:
         return 0
 
-    # 最初のメディアリレーションシップの音声データを取得
-    media_part = media_rels[0].target_part
-    audio_blob = media_part.blob
-    return _estimate_mp3_duration_ms(audio_blob)
+    max_duration = 0
+    for rel in media_rels:
+        audio_blob = rel.target_part.blob
+        duration = _estimate_mp3_duration_ms(audio_blob)
+        if duration > max_duration:
+            max_duration = duration
+    return max_duration
 
 
 def _estimate_mp3_duration_ms(data: bytes) -> int:
@@ -130,51 +134,146 @@ def _set_auto_advance(slide, advance_ms: int) -> None:
 def _add_auto_play_animation(slide) -> None:
     """スライドの音声シェイプに自動再生アニメーションを設定する。
 
+    既存のアニメーション（テキスト・図形等）を保持しつつ、
+    音声auto-playノードをmainSeqにマージする。
+
     PowerPointのアニメーション構造:
     p:timing > p:tnLst > p:par (tmRoot) > p:childTnLst > p:seq (mainSeq) >
     p:cTn > p:childTnLst > p:par > p:cTn > p:childTnLst > p:par > p:cTn >
     p:childTnLst > p:audio > p:cMediaNode > p:cTn + p:tgtEl
     """
-    # 音声シェイプのIDを取得
-    audio_shape_id = _find_audio_shape_id(slide)
-    if audio_shape_id is None:
+    audio_shape_ids = _find_audio_shape_ids(slide)
+    if not audio_shape_ids:
         return
 
-    # 既存のtiming要素を削除して再構築
     slide_elem = slide.element
     existing_timing = slide_elem.find(f"{{{_P_NS}}}timing")
-    if existing_timing is not None:
-        slide_elem.remove(existing_timing)
 
-    timing_xml = f"""<p:timing xmlns:p="{_P_NS}">
-  <p:tnLst>
-    <p:par>
-      <p:cTn id="1" dur="indefinite" restart="never" nodeType="tmRoot">
-        <p:childTnLst>
-          <p:seq concurrent="1" nextAc="seek">
-            <p:cTn id="2" dur="indefinite" nodeType="mainSeq">
-              <p:childTnLst>
+    if existing_timing is not None:
+        # 既存のtiming構造にaudioノードをマージ
+        _merge_audio_into_timing(existing_timing, audio_shape_ids)
+    else:
+        # timing要素がない場合は新規作成
+        timing_elem = _build_timing_xml(audio_shape_ids)
+        slide_elem.append(timing_elem)
+
+
+def _merge_audio_into_timing(
+    timing_elem: etree._Element, audio_shape_ids: list[int]
+) -> None:
+    """既存のp:timing構造に音声auto-playノードを追加する。
+
+    mainSeqのchildTnLstに音声用p:parを追加する。
+    既存のアニメーションはそのまま保持される。
+    """
+    # mainSeq (nodeType="mainSeq") を探す
+    main_seq_ctn = timing_elem.find(
+        f".//{{{_P_NS}}}cTn[@nodeType='mainSeq']"
+    )
+    if main_seq_ctn is None:
+        return
+
+    child_tn_lst = main_seq_ctn.find(f"{{{_P_NS}}}childTnLst")
+    if child_tn_lst is None:
+        child_tn_lst = etree.SubElement(main_seq_ctn, f"{{{_P_NS}}}childTnLst")
+
+    # 既存のaudioノードのspidを取得して重複を避ける
+    existing_spids: set[int] = set()
+    for spgt in timing_elem.iter(f"{{{_P_NS}}}spTgt"):
+        parent_audio = spgt.getparent()
+        while parent_audio is not None:
+            if parent_audio.tag == f"{{{_P_NS}}}audio":
+                spid = spgt.get("spid")
+                if spid is not None:
+                    existing_spids.add(int(spid))
+                break
+            parent_audio = parent_audio.getparent()
+
+    # 次のcTn idを算出
+    max_id = _get_max_ctn_id(timing_elem)
+
+    for shape_id in audio_shape_ids:
+        if shape_id in existing_spids:
+            continue
+        audio_par = _build_audio_par_xml(shape_id, max_id + 1)
+        child_tn_lst.append(audio_par)
+        max_id += 3  # 各audioノードはcTn idを3つ使う
+
+
+def _get_max_ctn_id(timing_elem: etree._Element) -> int:
+    """timing要素内の最大cTn idを取得する。"""
+    max_id = 0
+    for ctn in timing_elem.iter(f"{{{_P_NS}}}cTn"):
+        id_val = ctn.get("id")
+        if id_val is not None:
+            max_id = max(max_id, int(id_val))
+    return max_id
+
+
+def _build_audio_par_xml(
+    shape_id: int, start_id: int
+) -> etree._Element:
+    """音声auto-play用のp:parノードを構築する。"""
+    xml = f"""<p:par xmlns:p="{_P_NS}">
+  <p:cTn id="{start_id}" fill="hold">
+    <p:stCondLst>
+      <p:cond delay="0"/>
+    </p:stCondLst>
+    <p:childTnLst>
+      <p:par>
+        <p:cTn id="{start_id + 1}" fill="hold">
+          <p:stCondLst>
+            <p:cond delay="0"/>
+          </p:stCondLst>
+          <p:childTnLst>
+            <p:audio>
+              <p:cMediaNode>
+                <p:cTn id="{start_id + 2}" fill="hold" display="0">
+                  <p:stCondLst>
+                    <p:cond delay="0"/>
+                  </p:stCondLst>
+                </p:cTn>
+                <p:tgtEl>
+                  <p:spTgt spid="{shape_id}"/>
+                </p:tgtEl>
+              </p:cMediaNode>
+            </p:audio>
+          </p:childTnLst>
+        </p:cTn>
+      </p:par>
+    </p:childTnLst>
+  </p:cTn>
+</p:par>"""
+    return etree.fromstring(xml)
+
+
+def _build_timing_xml(audio_shape_ids: list[int]) -> etree._Element:
+    """音声auto-play用の完全なp:timing要素を構築する。"""
+    audio_pars = ""
+    ctn_id = 3
+    for shape_id in audio_shape_ids:
+        audio_pars += f"""
                 <p:par>
-                  <p:cTn id="3" fill="hold">
+                  <p:cTn id="{ctn_id}" fill="hold">
                     <p:stCondLst>
                       <p:cond delay="0"/>
                     </p:stCondLst>
                     <p:childTnLst>
                       <p:par>
-                        <p:cTn id="4" fill="hold">
+                        <p:cTn id="{ctn_id + 1}" fill="hold">
                           <p:stCondLst>
                             <p:cond delay="0"/>
                           </p:stCondLst>
                           <p:childTnLst>
                             <p:audio>
                               <p:cMediaNode>
-                                <p:cTn id="5" fill="hold" display="0">
+                                <p:cTn id="{ctn_id + 2}" fill="hold" display="0">
                                   <p:stCondLst>
                                     <p:cond delay="0"/>
                                   </p:stCondLst>
                                 </p:cTn>
                                 <p:tgtEl>
-                                  <p:spTgt spid="{audio_shape_id}"/>
+                                  <p:spTgt spid="{shape_id}"/>
                                 </p:tgtEl>
                               </p:cMediaNode>
                             </p:audio>
@@ -183,7 +282,17 @@ def _add_auto_play_animation(slide) -> None:
                       </p:par>
                     </p:childTnLst>
                   </p:cTn>
-                </p:par>
+                </p:par>"""
+        ctn_id += 3
+
+    timing_xml = f"""<p:timing xmlns:p="{_P_NS}">
+  <p:tnLst>
+    <p:par>
+      <p:cTn id="1" dur="indefinite" restart="never" nodeType="tmRoot">
+        <p:childTnLst>
+          <p:seq concurrent="1" nextAc="seek">
+            <p:cTn id="2" dur="indefinite" nodeType="mainSeq">
+              <p:childTnLst>{audio_pars}
               </p:childTnLst>
             </p:cTn>
             <p:prevCondLst>
@@ -202,25 +311,22 @@ def _add_auto_play_animation(slide) -> None:
     </p:par>
   </p:tnLst>
 </p:timing>"""
-
-    timing_elem = etree.fromstring(timing_xml)
-    slide_elem.append(timing_elem)
+    return etree.fromstring(timing_xml)
 
 
-def _find_audio_shape_id(slide) -> int | None:
-    """スライドから音声シェイプのIDを取得する。
+def _find_audio_shape_ids(slide) -> list[int]:
+    """スライドから全音声シェイプのIDを取得する。
 
-    a:audioFile要素を持つp:pic要素のcNvPr idを返す。
+    a:audioFile要素を持つp:pic要素のcNvPr idをリストで返す。
     """
+    ids: list[int] = []
     slide_elem = slide.element
-    # audioFile要素を持つnvPrを探す
     for audio_file in slide_elem.iter(f"{{{_A_NS}}}audioFile"):
-        # audioFile → nvPr → nvPicPr → cNvPr
         nv_pr = audio_file.getparent()
         if nv_pr is not None:
             nv_pic_pr = nv_pr.getparent()
             if nv_pic_pr is not None:
                 c_nv_pr = nv_pic_pr.find(f"{{{_P_NS}}}cNvPr")
                 if c_nv_pr is not None:
-                    return int(c_nv_pr.get("id"))
-    return None
+                    ids.append(int(c_nv_pr.get("id")))
+    return ids

--- a/daida_ai/lib/slideshow.py
+++ b/daida_ai/lib/slideshow.py
@@ -65,11 +65,14 @@ def configure_slideshow(
             else:
                 # 外部リンク/非MP3など計測不能 → フォールバック
                 advance_ms = unmeasurable_duration_ms + audio_buffer_ms
-            _add_auto_play_animation(slide)
         else:
             advance_ms = silent_duration_ms
 
+        # ECMA-376 CT_Slide: transition? は timing? より前に来る必要がある
+        # transitionを先に設定してからtimingを追加する
         _set_auto_advance(slide, advance_ms)
+        if has_audio_shapes:
+            _add_auto_play_animation(slide)
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     prs.save(str(output_path))

--- a/skills/daida-ai/SKILL.md
+++ b/skills/daida-ai/SKILL.md
@@ -18,7 +18,7 @@ description: >
 
 テーマ入力から完成プレゼンまでの一連のパイプラインを実行する。
 
-**パイプライン**: テーマ → アウトライン → コンテンツ充実化(JSON) → PPTX生成 → トークスクリプト → 音声合成 → 音声埋め込み
+**パイプライン**: テーマ → アウトライン → コンテンツ充実化(JSON) → PPTX生成 → トークスクリプト → 音声合成 → 音声埋め込み → スライドショー自動再生設定
 
 ## 前提条件
 
@@ -231,6 +231,27 @@ bash ${CLAUDE_SKILL_DIR}/scripts/run.sh synthesize_audio.py output/presentation.
 
 ```bash
 bash ${CLAUDE_SKILL_DIR}/scripts/run.sh embed_audio.py output/presentation.pptx output/audio/ output/presentation_with_audio.pptx
+```
+
+---
+
+## Step 6: スライドショー自動再生設定
+
+音声埋め込み済みPPTXに、自動ページ送りと音声自動再生を設定する。
+これにより、スライドショーを開始するだけで最後まで完全自動で再生される。
+
+- 音声付きスライド: 音声再生完了 + バッファ（デフォルト1秒）で自動ページ送り
+- 音声なしスライド（表紙・中表紙等）: 固定時間（デフォルト3秒）で自動ページ送り
+
+### スクリプト実行
+
+```bash
+bash ${CLAUDE_SKILL_DIR}/scripts/run.sh make_slideshow.py output/presentation_with_audio.pptx output/presentation_final.pptx
+```
+
+表示時間を調整する場合:
+```bash
+bash ${CLAUDE_SKILL_DIR}/scripts/run.sh make_slideshow.py output/presentation_with_audio.pptx output/presentation_final.pptx --silent-duration 5000 --audio-buffer 2000
 ```
 
 ---

--- a/skills/daida-ai/scripts/make_slideshow.py
+++ b/skills/daida-ai/scripts/make_slideshow.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Step6: スライドショー自動再生設定
+
+PPTXにauto-advance transitionとaudio auto-playを設定し、
+スライドショーを開始したら最後まで完全自動で走るようにする。
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from daida_ai.lib.slideshow import configure_slideshow
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="PPTXにスライドショー自動再生設定を追加する"
+    )
+    parser.add_argument("input", type=Path, help="入力PPTXファイルパス")
+    parser.add_argument("output", type=Path, help="出力PPTXファイルパス")
+    parser.add_argument(
+        "--silent-duration",
+        type=int,
+        default=3000,
+        help="音声なしスライドの表示時間（ミリ秒、デフォルト3000）",
+    )
+    parser.add_argument(
+        "--audio-buffer",
+        type=int,
+        default=1000,
+        help="音声再生後の余白（ミリ秒、デフォルト1000）",
+    )
+    args = parser.parse_args()
+
+    if not args.input.exists():
+        print(f"Error: {args.input} not found", file=sys.stderr)
+        sys.exit(1)
+
+    configure_slideshow(
+        args.input,
+        args.output,
+        silent_duration_ms=args.silent_duration,
+        audio_buffer_ms=args.audio_buffer,
+    )
+    print(f"Slideshow configured: {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/daida-ai/scripts/make_slideshow.py
+++ b/skills/daida-ai/scripts/make_slideshow.py
@@ -32,6 +32,12 @@ def main():
         default=1000,
         help="音声再生後の余白（ミリ秒、デフォルト1000）",
     )
+    parser.add_argument(
+        "--unmeasurable-duration",
+        type=int,
+        default=30000,
+        help="デュレーション計測不能時のフォールバック（ミリ秒、デフォルト30000）",
+    )
     args = parser.parse_args()
 
     if not args.input.exists():
@@ -43,6 +49,7 @@ def main():
         args.output,
         silent_duration_ms=args.silent_duration,
         audio_buffer_ms=args.audio_buffer,
+        unmeasurable_duration_ms=args.unmeasurable_duration,
     )
     print(f"Slideshow configured: {args.output}")
 

--- a/tests/test_e2e_pipeline.py
+++ b/tests/test_e2e_pipeline.py
@@ -1,4 +1,4 @@
-"""E2Eテスト: テーマ → アウトライン → JSON → PPTX → ノート → 音声埋め込み
+"""E2Eテスト: テーマ → アウトライン → JSON → PPTX → ノート → 音声埋め込み → スライドショー
 
 全パイプラインをプログラム的に通して動作検証する。
 音声合成（edge-tts/VOICEVOX）はネットワーク依存のためモックする。
@@ -15,6 +15,7 @@ from daida_ai.lib.slide_spec import validate_slide_spec, save_slide_spec, load_s
 from daida_ai.lib.slide_builder import build_presentation
 from daida_ai.lib.talk_script import read_notes, write_notes
 from daida_ai.lib.audio_embed import embed_audio_to_pptx
+from daida_ai.lib.slideshow import configure_slideshow
 
 
 # ── Step 1 相当: Markdownアウトライン ──
@@ -216,7 +217,7 @@ class TestE2EPipeline:
         assert len(reopened.slides) == 6
 
     def test_フルパイプライン(self, tmp_output_dir: Path):
-        """テーマ → アウトライン → JSON → PPTX → ノート更新 → 音声埋め込み"""
+        """テーマ → アウトライン → JSON → PPTX → ノート更新 → 音声埋め込み → スライドショー"""
         # Step 1: アウトラインパース
         outline = parse_outline(SAMPLE_OUTLINE)
         assert outline.title is not None
@@ -252,12 +253,34 @@ class TestE2EPipeline:
         count = embed_audio_to_pptx(pptx_path, audio_dir, final_path)
         assert count > 0
 
+        # Step 6: スライドショー自動再生設定
+        _ns = {"p": "http://schemas.openxmlformats.org/presentationml/2006/main"}
+        slideshow_path = tmp_output_dir / "slideshow.pptx"
+        configure_slideshow(final_path, slideshow_path)
+
         # 最終検証
-        final_prs = Presentation(str(final_path))
+        final_prs = Presentation(str(slideshow_path))
         assert len(final_prs.slides) == 6
 
+        # 全スライドにtransition（自動ページ送り）が設定されている
+        for slide in final_prs.slides:
+            trans = slide.element.find("p:transition", _ns)
+            assert trans is not None, "全スライドにtransitionが必要"
+            assert trans.get("advClick") == "0"
+            assert trans.get("advTm") is not None
+
+        # 音声付きスライドにtiming（音声auto-play）が設定されている
+        audio_slides_with_timing = 0
+        for slide in final_prs.slides:
+            timing = slide.element.find("p:timing", _ns)
+            if timing is not None:
+                audio_nodes = timing.findall(".//p:audio", _ns)
+                if audio_nodes:
+                    audio_slides_with_timing += 1
+        assert audio_slides_with_timing > 0, "音声付きスライドにtimingが必要"
+
         # ノートが更新されていることを確認
-        final_notes = read_notes(final_path)
+        final_notes = read_notes(slideshow_path)
         for i, note in enumerate(final_notes):
             if note:
                 assert "更新済み" in note

--- a/tests/test_slideshow.py
+++ b/tests/test_slideshow.py
@@ -332,28 +332,67 @@ class Testフォールバック:
     def test_音声シェイプありデュレーション不明でもauto_playが設定される(
         self, pptx_with_audio: Path, tmp_output_dir: Path
     ):
-        """音声シェイプが存在すれば、デュレーション不明でもtiming要素が追加される。
-        （_get_audio_duration_msが0を返しても、_find_audio_shape_idsで検出）
-        """
+        """音声シェイプが存在すれば、デュレーション不明でもtiming要素が追加される。"""
+        from unittest.mock import patch
+
         output = tmp_output_dir / "show_fallback.pptx"
-        configure_slideshow(pptx_with_audio, output)
+        # _estimate_mp3_duration_msを0返しにスタブ → 計測不能シナリオ
+        with patch(
+            "daida_ai.lib.slideshow._estimate_mp3_duration_ms", return_value=0
+        ):
+            configure_slideshow(pptx_with_audio, output)
 
         prs = Presentation(str(output))
-        # スライド1は音声あり → timing要素がある
+        # スライド1は音声シェイプあり → timing要素が追加される
         timing = prs.slides[1].element.find("p:timing", _ns)
         assert timing is not None
         audio_nodes = timing.findall(".//p:audio", _ns)
         assert len(audio_nodes) >= 1
 
-    def test_unmeasurable_duration_msが適用される(
+    def test_unmeasurable_duration_msがadvTmに反映される(
         self, pptx_with_audio: Path, tmp_output_dir: Path
     ):
-        """unmeasurable_duration_msパラメータのテスト"""
+        """デュレーション計測不能時にフォールバック値がadvTmに使われる"""
+        from unittest.mock import patch
+
         output = tmp_output_dir / "show_unmeasurable.pptx"
-        # デフォルト30000ms。通常のダミーMP3は計測可能なので直接テストが難しいが、
-        # パラメータが受け入れられることを確認
-        configure_slideshow(
-            pptx_with_audio, output, unmeasurable_duration_ms=15000
-        )
+        with patch(
+            "daida_ai.lib.slideshow._estimate_mp3_duration_ms", return_value=0
+        ):
+            configure_slideshow(
+                pptx_with_audio,
+                output,
+                unmeasurable_duration_ms=15000,
+                audio_buffer_ms=2000,
+            )
+
         prs = Presentation(str(output))
-        assert len(prs.slides) == 4
+        # スライド1は音声シェイプあり → advTm = 15000 + 2000 = 17000
+        slide1_trans = prs.slides[1].element.find("p:transition", _ns)
+        assert slide1_trans is not None
+        assert slide1_trans.get("advTm") == "17000"
+
+
+class TestXMLスキーマ順序:
+    """ECMA-376 CT_Slide: transition? は timing? より前に来る"""
+
+    def test_transitionがtimingより前に配置される(
+        self, pptx_with_audio: Path, tmp_output_dir: Path
+    ):
+        """音声付きスライドでtransitionとtimingの順序が正しい"""
+        output = tmp_output_dir / "show_order.pptx"
+        configure_slideshow(pptx_with_audio, output)
+
+        prs = Presentation(str(output))
+        slide_elem = prs.slides[1].element
+        children = list(slide_elem)
+        child_tags = [c.tag.split("}")[-1] for c in children]
+
+        # transitionとtimingが両方存在する場合、transitionが先
+        if "transition" in child_tags and "timing" in child_tags:
+            trans_idx = child_tags.index("transition")
+            timing_idx = child_tags.index("timing")
+            assert trans_idx < timing_idx, (
+                f"transition(idx={trans_idx}) must precede "
+                f"timing(idx={timing_idx})"
+            )

--- a/tests/test_slideshow.py
+++ b/tests/test_slideshow.py
@@ -374,7 +374,7 @@ class Testフォールバック:
 
 
 class TestXMLスキーマ順序:
-    """ECMA-376 CT_Slide: transition? は timing? より前に来る"""
+    """ECMA-376 CT_Slide: cSld, clrMapOvr?, transition?, timing?, hf?, extLst?"""
 
     def test_transitionがtimingより前に配置される(
         self, pptx_with_audio: Path, tmp_output_dir: Path
@@ -396,3 +396,70 @@ class TestXMLスキーマ順序:
                 f"transition(idx={trans_idx}) must precede "
                 f"timing(idx={timing_idx})"
             )
+
+    def test_既存timingがあるスライドでtransitionが正しい位置に挿入される(
+        self, pptx_with_audio: Path, tmp_output_dir: Path
+    ):
+        """既にtimingが存在するスライドにtransitionを追加した時の順序"""
+        from lxml import etree
+
+        _P = "http://schemas.openxmlformats.org/presentationml/2006/main"
+
+        # まず音声付きスライドにtimingだけ手動で追加した状態を作る
+        prs = Presentation(str(pptx_with_audio))
+        slide = prs.slides[1]
+        timing_xml = f"""<p:timing xmlns:p="{_P}">
+  <p:tnLst><p:par><p:cTn id="1" dur="indefinite" restart="never" nodeType="tmRoot">
+    <p:childTnLst><p:seq concurrent="1" nextAc="seek">
+      <p:cTn id="2" dur="indefinite" nodeType="mainSeq"><p:childTnLst/></p:cTn>
+      <p:prevCondLst><p:cond evt="onPrev" delay="0"><p:tgtEl><p:sldTgt/></p:tgtEl></p:cond></p:prevCondLst>
+      <p:nextCondLst><p:cond evt="onNext" delay="0"><p:tgtEl><p:sldTgt/></p:tgtEl></p:cond></p:nextCondLst>
+    </p:seq></p:childTnLst>
+  </p:cTn></p:par></p:tnLst>
+</p:timing>"""
+        slide.element.append(etree.fromstring(timing_xml))
+
+        pre_timing_path = tmp_output_dir / "pre_timing.pptx"
+        prs.save(str(pre_timing_path))
+
+        output = tmp_output_dir / "show_order_pre_timing.pptx"
+        configure_slideshow(pre_timing_path, output)
+
+        prs2 = Presentation(str(output))
+        child_tags = [
+            etree.QName(c).localname for c in prs2.slides[1].element
+        ]
+        assert "transition" in child_tags
+        assert "timing" in child_tags
+        assert child_tags.index("transition") < child_tags.index("timing")
+
+    def test_hf要素があるスライドでtransitionとtimingがhfの前に配置される(
+        self, pptx_no_audio: Path, tmp_output_dir: Path
+    ):
+        """p:hf（ヘッダー/フッター）が存在するスライドでの順序検証"""
+        from lxml import etree
+
+        _P = "http://schemas.openxmlformats.org/presentationml/2006/main"
+
+        # スライドにp:hf要素を手動追加
+        prs = Presentation(str(pptx_no_audio))
+        slide = prs.slides[0]
+        hf_elem = etree.Element(f"{{{_P}}}hf")
+        hf_elem.set("sldNum", "0")
+        slide.element.append(hf_elem)
+
+        with_hf_path = tmp_output_dir / "with_hf.pptx"
+        prs.save(str(with_hf_path))
+
+        output = tmp_output_dir / "show_order_hf.pptx"
+        configure_slideshow(with_hf_path, output)
+
+        prs2 = Presentation(str(output))
+        child_tags = [
+            etree.QName(c).localname for c in prs2.slides[0].element
+        ]
+        assert "transition" in child_tags
+        assert "hf" in child_tags
+        assert child_tags.index("transition") < child_tags.index("hf"), (
+            f"transition must precede hf, got: {child_tags}"
+        )

--- a/tests/test_slideshow.py
+++ b/tests/test_slideshow.py
@@ -324,3 +324,36 @@ class Test既存アニメーション保持:
 
         audio_nodes = timing.findall(".//p:audio", _ns)
         assert len(audio_nodes) == 1, "audioノードは1つだけであるべき"
+
+
+class Testフォールバック:
+    """デュレーション計測不能時のフォールバック動作を検証"""
+
+    def test_音声シェイプありデュレーション不明でもauto_playが設定される(
+        self, pptx_with_audio: Path, tmp_output_dir: Path
+    ):
+        """音声シェイプが存在すれば、デュレーション不明でもtiming要素が追加される。
+        （_get_audio_duration_msが0を返しても、_find_audio_shape_idsで検出）
+        """
+        output = tmp_output_dir / "show_fallback.pptx"
+        configure_slideshow(pptx_with_audio, output)
+
+        prs = Presentation(str(output))
+        # スライド1は音声あり → timing要素がある
+        timing = prs.slides[1].element.find("p:timing", _ns)
+        assert timing is not None
+        audio_nodes = timing.findall(".//p:audio", _ns)
+        assert len(audio_nodes) >= 1
+
+    def test_unmeasurable_duration_msが適用される(
+        self, pptx_with_audio: Path, tmp_output_dir: Path
+    ):
+        """unmeasurable_duration_msパラメータのテスト"""
+        output = tmp_output_dir / "show_unmeasurable.pptx"
+        # デフォルト30000ms。通常のダミーMP3は計測可能なので直接テストが難しいが、
+        # パラメータが受け入れられることを確認
+        configure_slideshow(
+            pptx_with_audio, output, unmeasurable_duration_ms=15000
+        )
+        prs = Presentation(str(output))
+        assert len(prs.slides) == 4

--- a/tests/test_slideshow.py
+++ b/tests/test_slideshow.py
@@ -1,0 +1,195 @@
+"""TDD: slideshow.py — スライドショー自動再生設定テスト"""
+
+import pytest
+from pathlib import Path
+from lxml import etree
+from pptx import Presentation
+
+from daida_ai.lib.slide_spec import SlideSpec, SlideMetadata, Slide
+from daida_ai.lib.slide_builder import build_presentation
+from daida_ai.lib.audio_embed import embed_audio_to_pptx
+from daida_ai.lib.slideshow import configure_slideshow
+
+# OOXML名前空間
+_ns = {
+    "p": "http://schemas.openxmlformats.org/presentationml/2006/main",
+    "a": "http://schemas.openxmlformats.org/drawingml/2006/main",
+}
+
+
+@pytest.fixture
+def pptx_with_audio(tmp_output_dir: Path) -> Path:
+    """音声埋め込み済みの4スライドPPTX"""
+    spec = SlideSpec(
+        metadata=SlideMetadata(title="LT", subtitle="Speaker", event="Event"),
+        slides=[
+            Slide(layout="title_slide", title="表紙"),
+            Slide(layout="title_and_content", title="内容1", body=["a"]),
+            Slide(layout="section_header", title="中表紙"),
+            Slide(layout="title_and_content", title="内容2", body=["b"]),
+        ],
+    )
+    prs = build_presentation(spec)
+    pptx_path = tmp_output_dir / "test.pptx"
+    prs.save(str(pptx_path))
+
+    # スライド1,3に音声を埋め込む（表紙と中表紙には音声なし）
+    audio_dir = tmp_output_dir / "audio"
+    audio_dir.mkdir()
+    # ダミーMP3（104バイト）
+    dummy_mp3 = b"\xff\xfb\x90\x00" + b"\x00" * 100
+    (audio_dir / "slide_001.mp3").write_bytes(dummy_mp3)
+    (audio_dir / "slide_003.mp3").write_bytes(dummy_mp3)
+
+    output = tmp_output_dir / "with_audio.pptx"
+    embed_audio_to_pptx(pptx_path, audio_dir, output)
+    return output
+
+
+@pytest.fixture
+def pptx_no_audio(tmp_output_dir: Path) -> Path:
+    """音声なしの2スライドPPTX"""
+    spec = SlideSpec(
+        metadata=SlideMetadata(title="LT", subtitle="S", event="E"),
+        slides=[
+            Slide(layout="title_slide", title="表紙"),
+            Slide(layout="title_and_content", title="内容", body=["a"]),
+        ],
+    )
+    prs = build_presentation(spec)
+    path = tmp_output_dir / "no_audio.pptx"
+    prs.save(str(path))
+    return path
+
+
+class Test自動ページ送り:
+    """全スライドにauto-advance transitionが設定される"""
+
+    def test_全スライドにtransition要素が追加される(
+        self, pptx_with_audio: Path, tmp_output_dir: Path
+    ):
+        output = tmp_output_dir / "show.pptx"
+        configure_slideshow(pptx_with_audio, output)
+
+        prs = Presentation(str(output))
+        for slide in prs.slides:
+            trans = slide.element.findall("p:transition", _ns)
+            assert len(trans) >= 1, "transition要素が必要"
+
+    def test_advClickが無効になる(
+        self, pptx_with_audio: Path, tmp_output_dir: Path
+    ):
+        """クリックでのページ送りを無効にする"""
+        output = tmp_output_dir / "show.pptx"
+        configure_slideshow(pptx_with_audio, output)
+
+        prs = Presentation(str(output))
+        for slide in prs.slides:
+            trans = slide.element.find("p:transition", _ns)
+            assert trans.get("advClick") == "0"
+
+    def test_音声なしスライドにデフォルト秒数が設定される(
+        self, pptx_with_audio: Path, tmp_output_dir: Path
+    ):
+        """表紙・中表紙など音声なしスライドは固定時間で進む"""
+        output = tmp_output_dir / "show.pptx"
+        configure_slideshow(pptx_with_audio, output, silent_duration_ms=4000)
+
+        prs = Presentation(str(output))
+        # スライド0 (表紙) と スライド2 (中表紙) は音声なし
+        slide0_trans = prs.slides[0].element.find("p:transition", _ns)
+        assert slide0_trans.get("advTm") == "4000"
+
+        slide2_trans = prs.slides[2].element.find("p:transition", _ns)
+        assert slide2_trans.get("advTm") == "4000"
+
+    def test_音声ありスライドの送り時間はデフォルトより長い(
+        self, pptx_with_audio: Path, tmp_output_dir: Path
+    ):
+        """音声付きスライドは音声長に基づいた時間で進む"""
+        output = tmp_output_dir / "show.pptx"
+        configure_slideshow(pptx_with_audio, output, silent_duration_ms=3000)
+
+        prs = Presentation(str(output))
+        # スライド1は音声あり → advTmはsilent_durationとは異なる値
+        slide1_trans = prs.slides[1].element.find("p:transition", _ns)
+        adv_tm = int(slide1_trans.get("advTm"))
+        # ダミーMP3は非常に短いが、最低でもバッファ分は確保される
+        assert adv_tm > 0
+
+    def test_音声なしPPTXでも動作する(
+        self, pptx_no_audio: Path, tmp_output_dir: Path
+    ):
+        output = tmp_output_dir / "show.pptx"
+        configure_slideshow(pptx_no_audio, output, silent_duration_ms=5000)
+
+        prs = Presentation(str(output))
+        for slide in prs.slides:
+            trans = slide.element.find("p:transition", _ns)
+            assert trans is not None
+            assert trans.get("advTm") == "5000"
+
+
+class Test音声自動再生:
+    """音声付きスライドにauto-playアニメーションが設定される"""
+
+    def test_音声付きスライドにtiming要素が追加される(
+        self, pptx_with_audio: Path, tmp_output_dir: Path
+    ):
+        output = tmp_output_dir / "show.pptx"
+        configure_slideshow(pptx_with_audio, output)
+
+        prs = Presentation(str(output))
+        # スライド1は音声あり → timing要素がある
+        timing = prs.slides[1].element.find("p:timing", _ns)
+        assert timing is not None
+
+    def test_音声なしスライドにtiming要素がない(
+        self, pptx_with_audio: Path, tmp_output_dir: Path
+    ):
+        output = tmp_output_dir / "show.pptx"
+        configure_slideshow(pptx_with_audio, output)
+
+        prs = Presentation(str(output))
+        # スライド0は音声なし → timing要素がないか空
+        timing = prs.slides[0].element.find("p:timing", _ns)
+        if timing is not None:
+            # timing要素があっても音声アニメーションはない
+            audio_nodes = timing.findall(".//p:audio", _ns)
+            assert len(audio_nodes) == 0
+
+    def test_出力ファイルが正常に開ける(
+        self, pptx_with_audio: Path, tmp_output_dir: Path
+    ):
+        output = tmp_output_dir / "show.pptx"
+        configure_slideshow(pptx_with_audio, output)
+
+        prs = Presentation(str(output))
+        assert len(prs.slides) == 4
+
+
+class Testカスタム設定:
+    """configure_slideshowのパラメータテスト"""
+
+    def test_silent_durationのデフォルトは3000ms(
+        self, pptx_no_audio: Path, tmp_output_dir: Path
+    ):
+        output = tmp_output_dir / "show.pptx"
+        configure_slideshow(pptx_no_audio, output)
+
+        prs = Presentation(str(output))
+        trans = prs.slides[0].element.find("p:transition", _ns)
+        assert trans.get("advTm") == "3000"
+
+    def test_audio_buffer_msが加算される(
+        self, pptx_with_audio: Path, tmp_output_dir: Path
+    ):
+        """音声の長さ + バッファ時間でadvTmが設定される"""
+        output = tmp_output_dir / "show.pptx"
+        configure_slideshow(pptx_with_audio, output, audio_buffer_ms=2000)
+
+        prs = Presentation(str(output))
+        slide1_trans = prs.slides[1].element.find("p:transition", _ns)
+        adv_tm = int(slide1_trans.get("advTm"))
+        # バッファ2000ms以上は確保されているはず
+        assert adv_tm >= 2000

--- a/tests/test_slideshow.py
+++ b/tests/test_slideshow.py
@@ -193,3 +193,134 @@ class Testカスタム設定:
         adv_tm = int(slide1_trans.get("advTm"))
         # バッファ2000ms以上は確保されているはず
         assert adv_tm >= 2000
+
+
+class Test既存アニメーション保持:
+    """既存のアニメーションが破壊されないことを検証"""
+
+    @pytest.fixture
+    def pptx_with_existing_animation(self, tmp_output_dir: Path) -> Path:
+        """既存アニメーション+音声付きPPTX"""
+        from lxml import etree
+
+        _P = "http://schemas.openxmlformats.org/presentationml/2006/main"
+
+        spec = SlideSpec(
+            metadata=SlideMetadata(title="LT", subtitle="S", event="E"),
+            slides=[
+                Slide(layout="title_slide", title="表紙"),
+                Slide(layout="title_and_content", title="内容", body=["a", "b"]),
+            ],
+        )
+        prs = build_presentation(spec)
+        pptx_path = tmp_output_dir / "base.pptx"
+        prs.save(str(pptx_path))
+
+        # スライド1に音声を埋め込む
+        audio_dir = tmp_output_dir / "audio_anim"
+        audio_dir.mkdir()
+        dummy_mp3 = b"\xff\xfb\x90\x00" + b"\x00" * 100
+        (audio_dir / "slide_001.mp3").write_bytes(dummy_mp3)
+        with_audio = tmp_output_dir / "with_audio_anim.pptx"
+        embed_audio_to_pptx(pptx_path, audio_dir, with_audio)
+
+        # スライド1に既存アニメーション（テキストフェードイン）を手動追加
+        prs2 = Presentation(str(with_audio))
+        slide = prs2.slides[1]
+        # shape id=2をターゲットにしたダミーアニメーション
+        timing_xml = f"""<p:timing xmlns:p="{_P}">
+  <p:tnLst>
+    <p:par>
+      <p:cTn id="1" dur="indefinite" restart="never" nodeType="tmRoot">
+        <p:childTnLst>
+          <p:seq concurrent="1" nextAc="seek">
+            <p:cTn id="2" dur="indefinite" nodeType="mainSeq">
+              <p:childTnLst>
+                <p:par>
+                  <p:cTn id="3" fill="hold">
+                    <p:stCondLst><p:cond delay="0"/></p:stCondLst>
+                    <p:childTnLst>
+                      <p:par>
+                        <p:cTn id="4" fill="hold">
+                          <p:stCondLst><p:cond delay="0"/></p:stCondLst>
+                          <p:childTnLst>
+                            <p:anim calcmode="lin" valueType="num">
+                              <p:cBhvr>
+                                <p:cTn id="5" dur="500" fill="hold"/>
+                                <p:tgtEl><p:spTgt spid="2"/></p:tgtEl>
+                                <p:attrNameLst><p:attrName>style.opacity</p:attrName></p:attrNameLst>
+                              </p:cBhvr>
+                            </p:anim>
+                          </p:childTnLst>
+                        </p:cTn>
+                      </p:par>
+                    </p:childTnLst>
+                  </p:cTn>
+                </p:par>
+              </p:childTnLst>
+            </p:cTn>
+            <p:prevCondLst>
+              <p:cond evt="onPrev" delay="0"><p:tgtEl><p:sldTgt/></p:tgtEl></p:cond>
+            </p:prevCondLst>
+            <p:nextCondLst>
+              <p:cond evt="onNext" delay="0"><p:tgtEl><p:sldTgt/></p:tgtEl></p:cond>
+            </p:nextCondLst>
+          </p:seq>
+        </p:childTnLst>
+      </p:cTn>
+    </p:par>
+  </p:tnLst>
+</p:timing>"""
+        timing_elem = etree.fromstring(timing_xml)
+        slide.element.append(timing_elem)
+
+        result = tmp_output_dir / "with_existing_anim.pptx"
+        prs2.save(str(result))
+        return result
+
+    def test_既存アニメーションが保持される(
+        self, pptx_with_existing_animation: Path, tmp_output_dir: Path
+    ):
+        """configure_slideshow後も既存のp:animノードが残る"""
+        output = tmp_output_dir / "show_anim.pptx"
+        configure_slideshow(pptx_with_existing_animation, output)
+
+        prs = Presentation(str(output))
+        timing = prs.slides[1].element.find("p:timing", _ns)
+        assert timing is not None
+
+        # 既存のアニメーション（p:anim）が残っている
+        anim_nodes = timing.findall(".//p:anim", _ns)
+        assert len(anim_nodes) >= 1, "既存のp:animアニメーションが保持されるべき"
+
+    def test_既存アニメーションに音声ノードが追加される(
+        self, pptx_with_existing_animation: Path, tmp_output_dir: Path
+    ):
+        """既存アニメーション構造に音声auto-playがマージされる"""
+        output = tmp_output_dir / "show_anim.pptx"
+        configure_slideshow(pptx_with_existing_animation, output)
+
+        prs = Presentation(str(output))
+        timing = prs.slides[1].element.find("p:timing", _ns)
+        assert timing is not None
+
+        # 音声auto-playノードが追加されている
+        audio_nodes = timing.findall(".//p:audio", _ns)
+        assert len(audio_nodes) >= 1, "音声auto-playノードが追加されるべき"
+
+    def test_二重実行しても音声ノードが重複しない(
+        self, pptx_with_audio: Path, tmp_output_dir: Path
+    ):
+        """configure_slideshowを2回実行してもaudioノードが重複しない"""
+        intermediate = tmp_output_dir / "show_pass1.pptx"
+        configure_slideshow(pptx_with_audio, intermediate)
+
+        output = tmp_output_dir / "show_pass2.pptx"
+        configure_slideshow(intermediate, output)
+
+        prs = Presentation(str(output))
+        timing = prs.slides[1].element.find("p:timing", _ns)
+        assert timing is not None
+
+        audio_nodes = timing.findall(".//p:audio", _ns)
+        assert len(audio_nodes) == 1, "audioノードは1つだけであるべき"


### PR DESCRIPTION
## Summary
- 新モジュール `slideshow.py` + スクリプト `make_slideshow.py` (Step 6)
- 音声付きスライド: 音声長 + バッファで自動ページ送り + 音声自動再生アニメーション
- 音声なしスライド（表紙・中表紙）: 固定時間（デフォルト3秒）で自動ページ送り
- 全スライドで `advClick="0"` によりクリック不要
- MP3デュレーションはビットレートから軽量推定（pydub依存なし）

## 動作
スライドショー開始 → 表紙3秒 → 内容1（音声再生→完了後1秒→次へ） → 中表紙3秒 → 内容2（音声再生→完了→次へ） → 終了

## Test plan
- [x] 10テスト追加、全96テスト通過
- [ ] 実際のPPTXをLibreOffice/PowerPointでスライドショー再生して確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)