### PR TITLE
feat: Extract synthesize_notes() library with tests

### DIFF
--- a/daida_ai/lib/synthesize.py
+++ b/daida_ai/lib/synthesize.py
@@ -1,0 +1,54 @@
+"""音声合成パイプライン
+
+スピーカーノートのリストからTTSエンジンで音声ファイルを生成する。
+空ノートはスキップし、slide_NNN.mp3 形式で出力する。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from daida_ai.lib.tts_engine import TTSEngine, get_engine
+
+
+async def synthesize_notes(
+    notes: list[str],
+    output_dir: Path,
+    *,
+    engine: TTSEngine | None = None,
+    engine_name: str | None = None,
+    voice: str | None = None,
+) -> list[Path | None]:
+    """ノートリストから音声ファイルを生成する。
+
+    Args:
+        notes: スライドごとのスピーカーノート
+        output_dir: 音声ファイル出力ディレクトリ
+        engine: TTSエンジンインスタンス（engine_nameと排他）
+        engine_name: エンジン名（"edge" / "voicevox"）
+        voice: 音声名（Noneでエンジンのデフォルト）
+
+    Returns:
+        スライドごとの音声ファイルパス（空ノートはNone）
+
+    Raises:
+        ValueError: engineもengine_nameも指定されない場合
+    """
+    if engine is None and engine_name is None:
+        raise ValueError("engine or engine_name must be specified")
+
+    if engine is None:
+        engine = get_engine(engine_name)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    results: list[Path | None] = []
+
+    for i, note in enumerate(notes):
+        if not note.strip():
+            results.append(None)
+            continue
+        output_path = output_dir / f"slide_{i:03d}.mp3"
+        await engine.synthesize(note, output_path, voice=voice)
+        results.append(output_path)
+
+    return results

--- a/skills/daida-ai/scripts/synthesize_audio.py
+++ b/skills/daida-ai/scripts/synthesize_audio.py
@@ -9,29 +9,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
 from daida_ai.lib.talk_script import read_notes
-from daida_ai.lib.tts_engine import get_engine
-
-
-async def _synthesize_all(
-    notes: list[str],
-    output_dir: Path,
-    engine_name: str,
-    voice: str | None,
-) -> list[Path]:
-    engine = get_engine(engine_name)
-    output_dir.mkdir(parents=True, exist_ok=True)
-    results = []
-
-    for i, note in enumerate(notes):
-        if not note.strip():
-            results.append(None)
-            continue
-        output_path = output_dir / f"slide_{i:03d}.mp3"
-        await engine.synthesize(note, output_path, voice=voice)
-        results.append(output_path)
-        print(f"  Slide {i}: {output_path}")
-
-    return results
+from daida_ai.lib.synthesize import synthesize_notes
 
 
 def main():
@@ -55,9 +33,13 @@ def main():
     non_empty = sum(1 for n in notes if n.strip())
     print(f"Synthesizing {non_empty} slides with {args.engine}...")
 
-    asyncio.run(
-        _synthesize_all(notes, args.output_dir, args.engine, args.voice)
+    results = asyncio.run(
+        synthesize_notes(
+            notes, args.output_dir, engine_name=args.engine, voice=args.voice
+        )
     )
+    generated = sum(1 for r in results if r is not None)
+    print(f"Generated {generated} audio files.")
     print("Done.")
 
 

--- a/tests/test_synthesize_audio.py
+++ b/tests/test_synthesize_audio.py
@@ -1,0 +1,196 @@
+"""TDD: synthesize.py — 音声合成パイプラインテスト
+
+TTSエンジンをモックし、ノート→音声ファイル生成のロジックを検証する。
+ネットワーク通信は一切行わない。
+"""
+
+import pytest
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+from daida_ai.lib.synthesize import synthesize_notes
+
+
+@pytest.fixture
+def mock_engine():
+    """モックTTSエンジン"""
+    engine = AsyncMock()
+
+    async def fake_synthesize(text, output_path, voice=None):
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(b"\xff\xfb\x90\x00" + b"\x00" * 50)
+        return output_path
+
+    engine.synthesize.side_effect = fake_synthesize
+    return engine
+
+
+class Test正常系:
+    """ノートから音声ファイルを生成する基本動作"""
+
+    @pytest.mark.asyncio
+    async def test_ノートありスライドの音声が生成される(
+        self, tmp_output_dir: Path, mock_engine
+    ):
+        notes = ["こんにちは", "", "ありがとう"]
+        audio_dir = tmp_output_dir / "audio"
+
+        results = await synthesize_notes(
+            notes, audio_dir, engine=mock_engine
+        )
+
+        assert len(results) == 3
+        assert results[0] == audio_dir / "slide_000.mp3"
+        assert results[1] is None  # 空ノートはスキップ
+        assert results[2] == audio_dir / "slide_002.mp3"
+
+    @pytest.mark.asyncio
+    async def test_生成されたファイルが存在する(
+        self, tmp_output_dir: Path, mock_engine
+    ):
+        notes = ["テスト"]
+        audio_dir = tmp_output_dir / "audio"
+
+        await synthesize_notes(notes, audio_dir, engine=mock_engine)
+
+        assert (audio_dir / "slide_000.mp3").exists()
+
+    @pytest.mark.asyncio
+    async def test_出力ディレクトリが自動作成される(
+        self, tmp_output_dir: Path, mock_engine
+    ):
+        notes = ["テスト"]
+        audio_dir = tmp_output_dir / "nested" / "audio"
+
+        await synthesize_notes(notes, audio_dir, engine=mock_engine)
+
+        assert audio_dir.exists()
+
+    @pytest.mark.asyncio
+    async def test_voice引数がエンジンに渡される(
+        self, tmp_output_dir: Path, mock_engine
+    ):
+        notes = ["テスト"]
+        audio_dir = tmp_output_dir / "audio"
+
+        await synthesize_notes(
+            notes, audio_dir, engine=mock_engine, voice="ja-JP-KeitaNeural"
+        )
+
+        _, kwargs = mock_engine.synthesize.call_args
+        assert kwargs.get("voice") == "ja-JP-KeitaNeural"
+
+    @pytest.mark.asyncio
+    async def test_エンジン名からエンジンを解決できる(
+        self, tmp_output_dir: Path
+    ):
+        """engine引数の代わりにengine_name文字列を渡せる"""
+        notes = ["テスト"]
+        audio_dir = tmp_output_dir / "audio"
+
+        with patch("daida_ai.lib.synthesize.get_engine") as mock_get:
+            mock_eng = AsyncMock()
+
+            async def fake_synth(text, output_path, voice=None):
+                output_path.parent.mkdir(parents=True, exist_ok=True)
+                output_path.write_bytes(b"\x00" * 10)
+                return output_path
+
+            mock_eng.synthesize.side_effect = fake_synth
+            mock_get.return_value = mock_eng
+
+            await synthesize_notes(
+                notes, audio_dir, engine_name="edge"
+            )
+
+            mock_get.assert_called_once_with("edge")
+
+
+class Test空ノート処理:
+    """空ノートやスペースのみのノートの処理"""
+
+    @pytest.mark.asyncio
+    async def test_空文字列はスキップされる(
+        self, tmp_output_dir: Path, mock_engine
+    ):
+        notes = ["", "", ""]
+        audio_dir = tmp_output_dir / "audio"
+
+        results = await synthesize_notes(
+            notes, audio_dir, engine=mock_engine
+        )
+
+        assert all(r is None for r in results)
+        mock_engine.synthesize.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_スペースのみのノートはスキップされる(
+        self, tmp_output_dir: Path, mock_engine
+    ):
+        notes = ["  \t\n  "]
+        audio_dir = tmp_output_dir / "audio"
+
+        results = await synthesize_notes(
+            notes, audio_dir, engine=mock_engine
+        )
+
+        assert results == [None]
+        mock_engine.synthesize.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_全スライド空でもエラーにならない(
+        self, tmp_output_dir: Path, mock_engine
+    ):
+        notes = []
+        audio_dir = tmp_output_dir / "audio"
+
+        results = await synthesize_notes(
+            notes, audio_dir, engine=mock_engine
+        )
+
+        assert results == []
+
+
+class Testファイル命名:
+    """出力ファイルの命名規則"""
+
+    @pytest.mark.asyncio
+    async def test_slide_NNN_mp3形式で命名される(
+        self, tmp_output_dir: Path, mock_engine
+    ):
+        notes = ["a"] * 5
+        audio_dir = tmp_output_dir / "audio"
+
+        results = await synthesize_notes(
+            notes, audio_dir, engine=mock_engine
+        )
+
+        expected_names = [f"slide_{i:03d}.mp3" for i in range(5)]
+        actual_names = [r.name for r in results]
+        assert actual_names == expected_names
+
+    @pytest.mark.asyncio
+    async def test_100スライド以上でも3桁ゼロ埋め(
+        self, tmp_output_dir: Path, mock_engine
+    ):
+        notes = [""] * 99 + ["テスト"]
+        audio_dir = tmp_output_dir / "audio"
+
+        results = await synthesize_notes(
+            notes, audio_dir, engine=mock_engine
+        )
+
+        assert results[99] == audio_dir / "slide_099.mp3"
+
+
+class Testエラーハンドリング:
+    """engine/engine_nameどちらも指定されない場合"""
+
+    @pytest.mark.asyncio
+    async def test_engine未指定でValueError(
+        self, tmp_output_dir: Path
+    ):
+        with pytest.raises(ValueError, match="engine"):
+            await synthesize_notes(
+                ["テスト"], tmp_output_dir / "audio"
+            )


### PR DESCRIPTION
## Summary
- `daida_ai/lib/synthesize.py` にコアロジック `synthesize_notes()` を抽出
- `synthesize_audio.py` スクリプトをライブラリ呼び出しにリファクタ
- 11テスト追加（正常系5、空ノート3、命名2、エラー1）、合計115 passed

## Test plan
- [x] 正常系: ノートあり/なしスライドの音声生成
- [x] 空ノート処理: 空文字列、スペースのみ、全空
- [x] ファイル命名: slide_NNN.mp3 形式、3桁ゼロ埋め
- [x] エラーハンドリング: engine未指定でValueError
- [x] engine_name文字列からの解決（get_engineモック）

🤖 Generated with [Claude Code](https://claude.com/claude-code)