### PR TITLE
fix: PowerPoint互換の音声埋め込みXML構造

### DIFF
--- a/daida_ai/lib/audio_embed.py
+++ b/daida_ai/lib/audio_embed.py
@@ -121,8 +121,14 @@ def _embed_audio_in_slide(prs, slide, audio_path: Path, slide_idx: int) -> None:
     )
     r_id_icon = slide.part.relate_to(icon_part, RT.IMAGE)
 
-    # 4. スライドXMLに音声シェイプを追加
-    _add_audio_shape(slide, r_id_audio, r_id_media, r_id_icon, slide_idx)
+    # 4. hlinkClick用のハイパーリンクリレーションシップを追加
+    #    ppaction://media は外部URIとして扱う
+    r_id_hlink = slide.part.rels.get_or_add_ext_rel(
+        RT.HYPERLINK, "ppaction://media"
+    )
+
+    # 5. スライドXMLに音声シェイプを追加
+    _add_audio_shape(slide, r_id_audio, r_id_media, r_id_icon, r_id_hlink, slide_idx)
 
 
 def _add_audio_shape(
@@ -130,12 +136,13 @@ def _add_audio_shape(
     r_id_audio: str,
     r_id_media: str,
     r_id_icon: str,
+    r_id_hlink: str,
     slide_idx: int,
 ) -> None:
     """スライドXMLにp:pic要素（音声コントロール）を追加する。
 
     PowerPoint互換のOOXML構造:
-    - p:cNvPr: hlinkClickなし（空r:idを避ける）
+    - p:cNvPr: a:hlinkClick (RT.HYPERLINK → ppaction://media)
     - p:nvPr: a:audioFile (RT.AUDIO) + p14:media拡張 (RT.MEDIA)
     - p:blipFill: a:blip (RT.IMAGE, アイコン画像)
     """
@@ -153,7 +160,9 @@ def _add_audio_shape(
         f'xmlns:p="{_nsmap["p"]}" '
         f'xmlns:p14="{_nsmap["p14"]}">'
         f'  <p:nvPicPr>'
-        f'    <p:cNvPr id="{shape_id}" name="Audio {slide_idx}"/>'
+        f'    <p:cNvPr id="{shape_id}" name="Audio {slide_idx}">'
+        f'      <a:hlinkClick r:id="{r_id_hlink}" action="ppaction://media"/>'
+        f'    </p:cNvPr>'
         f'    <p:cNvPicPr><a:picLocks noChangeAspect="1"/></p:cNvPicPr>'
         f'    <p:nvPr>'
         f'      <a:audioFile r:link="{r_id_audio}"/>'

--- a/daida_ai/lib/audio_embed.py
+++ b/daida_ai/lib/audio_embed.py
@@ -3,10 +3,17 @@
 python-pptxは音声の直接埋め込みAPIを持たないため、
 OPCパッケージレベルでメディアパーツを追加し、
 スライドXMLに音声シェイプ（p:pic + audioFile）を挿入する。
+
+PowerPoint互換性のため、以下の構造が必要:
+- RT.AUDIO リレーションシップ → a:audioFile r:link
+- RT.MEDIA リレーションシップ → p14:media r:embed
+- RT.IMAGE リレーションシップ → a:blip r:embed（アイコン画像）
 """
 
 from __future__ import annotations
 
+import struct
+import zlib
 from pathlib import Path
 from lxml import etree
 from pptx import Presentation
@@ -18,7 +25,31 @@ _nsmap = {
     "a": "http://schemas.openxmlformats.org/drawingml/2006/main",
     "r": "http://schemas.openxmlformats.org/officeDocument/2006/relationships",
     "p": "http://schemas.openxmlformats.org/presentationml/2006/main",
+    "p14": "http://schemas.microsoft.com/office/powerpoint/2010/main",
 }
+
+# p14:media拡張のURI
+_P14_MEDIA_URI = "{DAA4B4D4-6D71-4841-9C94-3DE7FCFB9230}"
+
+
+def _make_1x1_png() -> bytes:
+    """1x1透明PNGバイナリを生成する（音声シェイプのアイコンプレースホルダ用）。"""
+
+    def _chunk(chunk_type: bytes, data: bytes) -> bytes:
+        c = chunk_type + data
+        return struct.pack(">I", len(data)) + c + struct.pack(">I", zlib.crc32(c) & 0xFFFFFFFF)
+
+    signature = b"\x89PNG\r\n\x1a\n"
+    # IHDR: 1x1, 8-bit RGBA
+    ihdr_data = struct.pack(">IIBBBBB", 1, 1, 8, 6, 0, 0, 0)
+    # IDAT: 1 transparent pixel (filter byte 0 + RGBA 0,0,0,0)
+    raw_data = b"\x00\x00\x00\x00\x00"
+    idat_data = zlib.compress(raw_data)
+    return signature + _chunk(b"IHDR", ihdr_data) + _chunk(b"IDAT", idat_data) + _chunk(b"IEND", b"")
+
+
+# モジュールレベルでキャッシュ
+_ICON_PNG = _make_1x1_png()
 
 
 def embed_audio_to_pptx(
@@ -58,9 +89,10 @@ def embed_audio_to_pptx(
 def _embed_audio_in_slide(prs, slide, audio_path: Path, slide_idx: int) -> None:
     """単一スライドに音声ファイルを埋め込む。
 
-    1. OPCパッケージに音声パーツを追加
-    2. スライドパーツからリレーションシップ(RT.MEDIA)を追加
-    3. スライドXMLにp:pic要素（audioFile参照付き）を挿入
+    PowerPoint互換のため3つのリレーションシップを作成:
+    1. RT.AUDIO → a:audioFile r:link 用
+    2. RT.MEDIA → p14:media r:embed 用
+    3. RT.IMAGE → a:blip r:embed 用（アイコン画像）
     """
     audio_data = audio_path.read_bytes()
     part_name = f"/ppt/media/audio_slide{slide_idx:03d}.mp3"
@@ -73,18 +105,39 @@ def _embed_audio_in_slide(prs, slide, audio_path: Path, slide_idx: int) -> None:
         blob=audio_data,
     )
 
-    # 2. リレーションシップを追加（rIdを取得）
-    r_id = slide.part.relate_to(audio_part, RT.MEDIA)
+    # 2. リレーションシップを追加
+    # RT.AUDIO: a:audioFile r:link が参照する
+    r_id_audio = slide.part.relate_to(audio_part, RT.AUDIO)
+    # RT.MEDIA: p14:media r:embed が参照する
+    r_id_media = slide.part.relate_to(audio_part, RT.MEDIA)
 
-    # 3. スライドXMLに音声シェイプを追加
-    _add_audio_shape(slide, r_id, slide_idx)
+    # 3. アイコン画像パーツを作成
+    icon_part_name = f"/ppt/media/audio_icon{slide_idx:03d}.png"
+    icon_part = Part(
+        PackURI(icon_part_name),
+        "image/png",
+        prs.part.package,
+        blob=_ICON_PNG,
+    )
+    r_id_icon = slide.part.relate_to(icon_part, RT.IMAGE)
+
+    # 4. スライドXMLに音声シェイプを追加
+    _add_audio_shape(slide, r_id_audio, r_id_media, r_id_icon, slide_idx)
 
 
-def _add_audio_shape(slide, r_id: str, slide_idx: int) -> None:
+def _add_audio_shape(
+    slide,
+    r_id_audio: str,
+    r_id_media: str,
+    r_id_icon: str,
+    slide_idx: int,
+) -> None:
     """スライドXMLにp:pic要素（音声コントロール）を追加する。
 
-    音声アイコンはスライドの右下に小さく配置し、
-    自動再生設定を含める。
+    PowerPoint互換のOOXML構造:
+    - p:cNvPr: hlinkClickなし（空r:idを避ける）
+    - p:nvPr: a:audioFile (RT.AUDIO) + p14:media拡張 (RT.MEDIA)
+    - p:blipFill: a:blip (RT.IMAGE, アイコン画像)
     """
     # スライド上の位置（右下、小さいアイコン）
     x = Emu(8229600)   # ~3.2 inches from left
@@ -94,22 +147,25 @@ def _add_audio_shape(slide, r_id: str, slide_idx: int) -> None:
 
     shape_id = 10000 + slide_idx
 
-    # p:pic 要素を構築（音声シェイプとして）
     pic_xml = (
         f'<p:pic xmlns:a="{_nsmap["a"]}" '
         f'xmlns:r="{_nsmap["r"]}" '
-        f'xmlns:p="{_nsmap["p"]}">'
+        f'xmlns:p="{_nsmap["p"]}" '
+        f'xmlns:p14="{_nsmap["p14"]}">'
         f'  <p:nvPicPr>'
-        f'    <p:cNvPr id="{shape_id}" name="Audio {slide_idx}">'
-        f'      <a:hlinkClick r:id="" action="ppaction://media"/>'
-        f'    </p:cNvPr>'
+        f'    <p:cNvPr id="{shape_id}" name="Audio {slide_idx}"/>'
         f'    <p:cNvPicPr><a:picLocks noChangeAspect="1"/></p:cNvPicPr>'
         f'    <p:nvPr>'
-        f'      <a:audioFile r:link="{r_id}"/>'
+        f'      <a:audioFile r:link="{r_id_audio}"/>'
+        f'      <p:extLst>'
+        f'        <p:ext uri="{_P14_MEDIA_URI}">'
+        f'          <p14:media r:embed="{r_id_media}"/>'
+        f'        </p:ext>'
+        f'      </p:extLst>'
         f'    </p:nvPr>'
         f'  </p:nvPicPr>'
         f'  <p:blipFill>'
-        f'    <a:blip/>'
+        f'    <a:blip r:embed="{r_id_icon}"/>'
         f'    <a:stretch><a:fillRect/></a:stretch>'
         f'  </p:blipFill>'
         f'  <p:spPr>'
@@ -123,7 +179,6 @@ def _add_audio_shape(slide, r_id: str, slide_idx: int) -> None:
     )
 
     pic_element = etree.fromstring(pic_xml)
-    # slide.element はスライドのXMLルート要素（CT_Slide）
     slide_element = slide.element
     sp_tree = slide_element.find(
         ".//{http://schemas.openxmlformats.org/presentationml/2006/main}spTree"

--- a/tests/test_audio_embedding.py
+++ b/tests/test_audio_embedding.py
@@ -220,16 +220,37 @@ class TestPowerPoint互換性:
         r_embed = blip.get(f"{{{self._ns['r']}}}embed")
         assert r_embed, "a:blipにr:embed属性が必要"
 
-    def test_hlinkClickのr_idが空でない(
+    def test_hlinkClickがppaction_mediaを参照する(
         self, pptx_path: Path, audio_dir: Path, tmp_output_dir: Path
     ):
-        """a:hlinkClick r:idが空文字列でないこと（または要素自体が不要）"""
+        """音声シェイプのa:hlinkClickがRT.HYPERLINKでppaction://mediaを参照すること"""
         output = tmp_output_dir / "output.pptx"
         embed_audio_to_pptx(pptx_path, audio_dir, output)
 
         prs = Presentation(str(output))
-        slide_xml = prs.slides[0].element
-        hlink = slide_xml.find(".//a:hlinkClick", self._ns)
-        if hlink is not None:
-            r_id = hlink.get(f"{{{self._ns['r']}}}id")
-            assert r_id != "", "hlinkClick r:idは空文字列であってはならない"
+        slide = prs.slides[0]
+        # 音声シェイプ内のhlinkClickを取得
+        pics = slide.element.findall(".//p:pic", self._ns)
+        audio_pic = None
+        for pic in pics:
+            if pic.find(".//a:audioFile", self._ns) is not None:
+                audio_pic = pic
+                break
+        assert audio_pic is not None, "音声シェイプが必要"
+
+        hlink = audio_pic.find(".//a:hlinkClick", self._ns)
+        assert hlink is not None, "a:hlinkClick要素が必要"
+
+        r_id = hlink.get(f"{{{self._ns['r']}}}id")
+        assert r_id and r_id != "", "hlinkClick r:idは空であってはならない"
+
+        action = hlink.get("action")
+        assert action == "ppaction://media", (
+            f"actionはppaction://mediaであるべき、実際: {action}"
+        )
+
+        # リレーションシップがRT.HYPERLINKであること
+        rel = slide.part.rels[r_id]
+        assert rel.reltype == RT.HYPERLINK, (
+            f"hlinkClickはRT.HYPERLINKを参照すべき、実際: {rel.reltype}"
+        )

--- a/tests/test_audio_embedding.py
+++ b/tests/test_audio_embedding.py
@@ -127,3 +127,109 @@ class TestEmbedAudio:
         ns = {"a": "http://schemas.openxmlformats.org/drawingml/2006/main"}
         audio_refs = slide0_xml.findall(".//a:audioFile", ns)
         assert len(audio_refs) > 0
+
+
+class TestPowerPoint互換性:
+    """PowerPointが要求するOOXML準拠の音声埋め込み構造を検証"""
+
+    _ns = {
+        "p": "http://schemas.openxmlformats.org/presentationml/2006/main",
+        "a": "http://schemas.openxmlformats.org/drawingml/2006/main",
+        "r": "http://schemas.openxmlformats.org/officeDocument/2006/relationships",
+        "p14": "http://schemas.microsoft.com/office/powerpoint/2010/main",
+    }
+
+    def test_RT_AUDIOリレーションシップが存在する(
+        self, pptx_path: Path, audio_dir: Path, tmp_output_dir: Path
+    ):
+        """audioFile r:linkはRT.AUDIO型のリレーションシップを参照すべき"""
+        output = tmp_output_dir / "output.pptx"
+        embed_audio_to_pptx(pptx_path, audio_dir, output)
+
+        prs = Presentation(str(output))
+        slide0_rels = prs.slides[0].part.rels
+        audio_rels = [r for r in slide0_rels.values() if r.reltype == RT.AUDIO]
+        assert len(audio_rels) > 0, "RT.AUDIOリレーションシップが必要"
+
+    def test_audioFileのr_linkがRT_AUDIOを参照する(
+        self, pptx_path: Path, audio_dir: Path, tmp_output_dir: Path
+    ):
+        """a:audioFile r:linkの参照先がRT.AUDIOリレーションシップであること"""
+        output = tmp_output_dir / "output.pptx"
+        embed_audio_to_pptx(pptx_path, audio_dir, output)
+
+        prs = Presentation(str(output))
+        slide = prs.slides[0]
+        audio_file = slide.element.find(".//a:audioFile", self._ns)
+        r_link = audio_file.get(f"{{{self._ns['r']}}}link")
+
+        # r_linkが指すリレーションシップの型を確認
+        rel = slide.part.rels[r_link]
+        assert rel.reltype == RT.AUDIO, (
+            f"audioFile r:linkはRT.AUDIOを参照すべき、実際: {rel.reltype}"
+        )
+
+    def test_p14_media拡張要素が存在する(
+        self, pptx_path: Path, audio_dir: Path, tmp_output_dir: Path
+    ):
+        """PowerPoint 2010+はp14:media拡張要素を要求する"""
+        output = tmp_output_dir / "output.pptx"
+        embed_audio_to_pptx(pptx_path, audio_dir, output)
+
+        prs = Presentation(str(output))
+        slide_xml = prs.slides[0].element
+        p14_media = slide_xml.findall(".//p14:media", self._ns)
+        assert len(p14_media) > 0, "p14:media拡張要素が必要"
+
+    def test_p14_mediaのr_embedがRT_MEDIAを参照する(
+        self, pptx_path: Path, audio_dir: Path, tmp_output_dir: Path
+    ):
+        """p14:media r:embedの参照先がRT.MEDIAリレーションシップであること"""
+        output = tmp_output_dir / "output.pptx"
+        embed_audio_to_pptx(pptx_path, audio_dir, output)
+
+        prs = Presentation(str(output))
+        slide = prs.slides[0]
+        p14_media = slide.element.find(".//p14:media", self._ns)
+        r_embed = p14_media.get(f"{{{self._ns['r']}}}embed")
+
+        rel = slide.part.rels[r_embed]
+        assert rel.reltype == RT.MEDIA, (
+            f"p14:media r:embedはRT.MEDIAを参照すべき、実際: {rel.reltype}"
+        )
+
+    def test_blipにr_embed属性がある(
+        self, pptx_path: Path, audio_dir: Path, tmp_output_dir: Path
+    ):
+        """a:blipにr:embed属性があり空でないこと"""
+        output = tmp_output_dir / "output.pptx"
+        embed_audio_to_pptx(pptx_path, audio_dir, output)
+
+        prs = Presentation(str(output))
+        slide_xml = prs.slides[0].element
+        # 音声シェイプのblipを取得
+        pics = slide_xml.findall(".//p:pic", self._ns)
+        audio_pic = None
+        for pic in pics:
+            if pic.find(".//a:audioFile", self._ns) is not None:
+                audio_pic = pic
+                break
+        assert audio_pic is not None
+
+        blip = audio_pic.find(".//a:blip", self._ns)
+        r_embed = blip.get(f"{{{self._ns['r']}}}embed")
+        assert r_embed, "a:blipにr:embed属性が必要"
+
+    def test_hlinkClickのr_idが空でない(
+        self, pptx_path: Path, audio_dir: Path, tmp_output_dir: Path
+    ):
+        """a:hlinkClick r:idが空文字列でないこと（または要素自体が不要）"""
+        output = tmp_output_dir / "output.pptx"
+        embed_audio_to_pptx(pptx_path, audio_dir, output)
+
+        prs = Presentation(str(output))
+        slide_xml = prs.slides[0].element
+        hlink = slide_xml.find(".//a:hlinkClick", self._ns)
+        if hlink is not None:
+            r_id = hlink.get(f"{{{self._ns['r']}}}id")
+            assert r_id != "", "hlinkClick r:idは空文字列であってはならない"


### PR DESCRIPTION
## Summary
- PowerPointでPPTXが開けない問題を修正（LibreOfficeでは開けていた）
- 音声埋め込みのOOXML構造を PowerPoint 2010+ 互換に修正
- RT.AUDIO + RT.MEDIA の2リレーションシップ体制に変更
- p14:media拡張要素を追加
- 空r:id hlinkClickを削除、a:blipにアイコン参照を追加

## Test plan
- [x] RT.AUDIOリレーションシップが存在する
- [x] audioFile r:linkがRT.AUDIOを参照する
- [x] p14:media拡張要素が存在する
- [x] p14:media r:embedがRT.MEDIAを参照する
- [x] a:blipにr:embed属性がある
- [x] hlinkClick r:idが空でない
- [x] 既存7テスト全パス + 新規6テスト = 全13テストパス
- [x] フルスイート263テストパス（E2E・slideshow含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)