### PR TITLE
fix: LibreOffice自動ページ送り対応 — mainSeq dur を音声長に設定

### DIFF
--- a/daida_ai/lib/slideshow.py
+++ b/daida_ai/lib/slideshow.py
@@ -93,7 +93,11 @@ def configure_slideshow(
             # notifySlideAnimationsEnded() が呼ばれず advTm が発火しない。
             # 音声長を dur に設定することで音声終了時にアニメーションが終わり、
             # LibreOffice のページ自動送りが正しく動作する。
-            main_seq_dur_ms = audio_duration if audio_duration > 0 else unmeasurable_duration_ms
+            # LibreOffice互換のため mainSeq.dur は必ず正の値にする。
+            # unmeasurable_duration_ms が 0 以下の場合でも最低 1ms を保証し、
+            # "indefinite" のまま残ることを防ぐ。
+            raw_dur = audio_duration if audio_duration > 0 else unmeasurable_duration_ms
+            main_seq_dur_ms = max(raw_dur, 1)
             _add_auto_play_animation(slide, main_seq_dur_ms=main_seq_dur_ms)
 
     output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/daida_ai/lib/slideshow.py
+++ b/daida_ai/lib/slideshow.py
@@ -315,23 +315,48 @@ def _merge_audio_into_timing(
 
 
 def _get_max_child_animation_dur_ms(main_seq_ctn: etree._Element) -> int:
-    """mainSeq の childTnLst 内の既存アニメーション最大時間(ms)を返す。
+    """mainSeq の childTnLst 内の既存アニメーション終了時刻の最大値(ms)を返す。
 
-    音声ノード (dur属性なし) はカウントしない。
-    明示的な数値 dur を持つ cTn の最大値を返す。
+    各 p:par の「開始遅延 + サブツリー最大dur」を計算して最大値を返す。
+    開始遅延は p:cTn/p:stCondLst/p:cond/@delay から取得する。
+    音声ノード (dur属性なし) は実質カウントされない。
     """
     child_tn_lst = main_seq_ctn.find(f"{{{_P_NS}}}childTnLst")
     if child_tn_lst is None:
         return 0
-    max_dur = 0
-    for ctn in child_tn_lst.iter(f"{{{_P_NS}}}cTn"):
-        dur_val = ctn.get("dur")
-        if dur_val is not None and dur_val != "indefinite":
-            try:
-                max_dur = max(max_dur, int(dur_val))
-            except ValueError:
-                pass
-    return max_dur
+
+    max_end = 0
+    for par in child_tn_lst.findall(f"{{{_P_NS}}}par"):
+        ctn = par.find(f"{{{_P_NS}}}cTn")
+        if ctn is None:
+            continue
+
+        # 開始遅延: p:cTn/p:stCondLst/p:cond/@delay
+        start_delay = 0
+        st_cond = ctn.find(
+            f"{{{_P_NS}}}stCondLst/{{{_P_NS}}}cond"
+        )
+        if st_cond is not None:
+            delay_val = st_cond.get("delay", "0")
+            if delay_val != "indefinite":
+                try:
+                    start_delay = int(delay_val)
+                except ValueError:
+                    pass
+
+        # サブツリー内の最大 dur (音声ノードはdur属性なしのためスキップされる)
+        max_dur = 0
+        for sub_ctn in ctn.iter(f"{{{_P_NS}}}cTn"):
+            dur_val = sub_ctn.get("dur")
+            if dur_val is not None and dur_val != "indefinite":
+                try:
+                    max_dur = max(max_dur, int(dur_val))
+                except ValueError:
+                    pass
+
+        max_end = max(max_end, start_delay + max_dur)
+
+    return max_end
 
 
 def _get_max_ctn_id(timing_elem: etree._Element) -> int:

--- a/daida_ai/lib/slideshow.py
+++ b/daida_ai/lib/slideshow.py
@@ -421,43 +421,53 @@ def _get_max_child_animation_dur_ms(main_seq_ctn: etree._Element) -> int:
 
     # Step 3: evt="onEnd" 依存を解決して開始時刻を計算
     par_starts: dict[int, int] = {}
+    _computing: set[int] = set()  # 循環参照検出用
 
     def get_start(idx: int) -> int:
         if idx in par_starts:
             return par_starts[idx]
-
-        par = par_list[idx]
-        outer_ctn = par.find(f"{{{_P_NS}}}cTn")
-        if outer_ctn is None:
+        if idx in _computing:
+            # 循環参照検出: 独立開始(0ms)として扱い RecursionError を防ぐ
             par_starts[idx] = 0
             return 0
 
-        own_delay = _get_ctn_start_delay(outer_ctn)
-        st_cond = outer_ctn.find(f"{{{_P_NS}}}stCondLst/{{{_P_NS}}}cond")
+        _computing.add(idx)
+        try:
+            par = par_list[idx]
+            outer_ctn = par.find(f"{{{_P_NS}}}cTn")
+            if outer_ctn is None:
+                par_starts[idx] = 0
+                return 0
 
-        if st_cond is not None:
-            evt = st_cond.get("evt")
-            if evt == "onClick":
-                # クリックトリガーは無人再生では発動しないためスキップ (-1 = sentinel)
-                par_starts[idx] = -1
-                return -1
-            tn_ref = st_cond.find(f"{{{_P_NS}}}tn")
-            if evt in ("onEnd", "onBegin") and tn_ref is not None:
-                ref_id = tn_ref.get("val")
-                ref_par_idx = ctn_id_to_par_idx.get(ref_id)
-                if ref_par_idx is not None and ref_par_idx != idx:
-                    ref_start = get_start(ref_par_idx)
-                    if evt == "onEnd":
-                        # After Previous: 参照アニメーション終了後に開始
-                        base = ref_start + par_internal_durs[ref_par_idx]
-                    else:
-                        # With Previous (onBegin): 参照アニメーション開始と同時
-                        base = ref_start
-                    par_starts[idx] = base + own_delay
-                    return par_starts[idx]
+            own_delay = _get_ctn_start_delay(outer_ctn)
+            st_cond = outer_ctn.find(f"{{{_P_NS}}}stCondLst/{{{_P_NS}}}cond")
 
-        par_starts[idx] = own_delay
-        return own_delay
+            if st_cond is not None:
+                evt = st_cond.get("evt")
+                if evt == "onClick":
+                    # クリックトリガーは無人再生では発動しないためスキップ (-1 = sentinel)
+                    par_starts[idx] = -1
+                    return -1
+                tn_ref = st_cond.find(f"{{{_P_NS}}}tn")
+                if evt in ("onEnd", "onBegin") and tn_ref is not None:
+                    ref_id = tn_ref.get("val")
+                    ref_par_idx = ctn_id_to_par_idx.get(ref_id)
+                    if ref_par_idx is not None and ref_par_idx != idx:
+                        ref_start = get_start(ref_par_idx)
+                        if ref_start >= 0:
+                            if evt == "onEnd":
+                                # After Previous: 参照アニメーション終了後に開始
+                                base = ref_start + par_internal_durs[ref_par_idx]
+                            else:
+                                # With Previous (onBegin): 参照アニメーション開始と同時
+                                base = ref_start
+                            par_starts[idx] = base + own_delay
+                            return par_starts[idx]
+
+            par_starts[idx] = own_delay
+            return own_delay
+        finally:
+            _computing.discard(idx)
 
     max_end = 0
     for i in range(len(par_list)):

--- a/daida_ai/lib/slideshow.py
+++ b/daida_ai/lib/slideshow.py
@@ -88,6 +88,10 @@ def configure_slideshow(
                 advance_ms = note_duration
             else:
                 advance_ms = silent_duration_ms
+            # 音声なしスライドでも既存アニメーション長を考慮する
+            existing_end = _get_existing_anim_end_ms(slide)
+            if existing_end > 0:
+                advance_ms = max(advance_ms, existing_end + audio_buffer_ms)
 
         # ECMA-376 CT_Slide: transition? は timing? より前に来る必要がある
         # transitionを先に設定してからtimingを追加する
@@ -379,25 +383,67 @@ def _calc_par_end_ms(par_elem: etree._Element, parent_delay: int) -> int:
 def _get_max_child_animation_dur_ms(main_seq_ctn: etree._Element) -> int:
     """mainSeq の childTnLst 内の既存アニメーション終了時刻の最大値(ms)を返す。
 
-    各 p:par の終了時刻を _calc_par_end_ms で再帰計算し最大値を返す。
+    各 p:par の終了時刻を再帰計算し、evt="onEnd" による連鎖も解決する。
     音声ノード (dur属性なし) は実質カウントされない。
-
-    **スコープ制限**: この実装は p:stCondLst/p:cond/@delay による明示的な
-    絶対遅延を処理する。PowerPoint の "After Previous" アニメーション
-    (p:prevCondLst/p:nextCondLst または evt="onEnd" 等のイベント条件) による
-    連鎖は解析しない（依存グラフ解決が必要なため）。
-
-    daida-ai が生成するスライドには "After Previous" アニメーションは存在しない
-    ため、このツールの実用上の問題はない。外部 PPTX で複雑なアニメーション
-    チェーンが含まれる場合は、計算値が実際の終了時刻より短くなる可能性がある。
     """
     child_tn_lst = main_seq_ctn.find(f"{{{_P_NS}}}childTnLst")
     if child_tn_lst is None:
         return 0
 
+    par_list = child_tn_lst.findall(f"{{{_P_NS}}}par")
+    if not par_list:
+        return 0
+
+    # Step 1: cTn id → par index マップを構築
+    ctn_id_to_par_idx: dict[str, int] = {}
+    for i, par in enumerate(par_list):
+        for ctn in par.iter(f"{{{_P_NS}}}cTn"):
+            ctn_id = ctn.get("id")
+            if ctn_id:
+                ctn_id_to_par_idx[ctn_id] = i
+
+    # Step 2: 各 par の内部所要時間を計算（outer stCondLst の遅延を除く）
+    par_internal_durs: list[int] = []
+    for par in par_list:
+        outer_ctn = par.find(f"{{{_P_NS}}}cTn")
+        own_delay = _get_ctn_start_delay(outer_ctn) if outer_ctn is not None else 0
+        total_end = _calc_par_end_ms(par, 0)
+        par_internal_durs.append(max(0, total_end - own_delay))
+
+    # Step 3: evt="onEnd" 依存を解決して開始時刻を計算
+    par_starts: dict[int, int] = {}
+
+    def get_start(idx: int) -> int:
+        if idx in par_starts:
+            return par_starts[idx]
+
+        par = par_list[idx]
+        outer_ctn = par.find(f"{{{_P_NS}}}cTn")
+        if outer_ctn is None:
+            par_starts[idx] = 0
+            return 0
+
+        own_delay = _get_ctn_start_delay(outer_ctn)
+        st_cond = outer_ctn.find(f"{{{_P_NS}}}stCondLst/{{{_P_NS}}}cond")
+
+        if st_cond is not None and st_cond.get("evt") == "onEnd":
+            tn_ref = st_cond.find(f"{{{_P_NS}}}tn")
+            if tn_ref is not None:
+                ref_id = tn_ref.get("val")
+                ref_par_idx = ctn_id_to_par_idx.get(ref_id)
+                if ref_par_idx is not None and ref_par_idx != idx:
+                    ref_start = get_start(ref_par_idx)
+                    ref_end = ref_start + par_internal_durs[ref_par_idx]
+                    par_starts[idx] = ref_end + own_delay
+                    return par_starts[idx]
+
+        par_starts[idx] = own_delay
+        return own_delay
+
     max_end = 0
-    for par in child_tn_lst.findall(f"{{{_P_NS}}}par"):
-        max_end = max(max_end, _calc_par_end_ms(par, 0))
+    for i in range(len(par_list)):
+        end = get_start(i) + par_internal_durs[i]
+        max_end = max(max_end, end)
     return max_end
 
 

--- a/daida_ai/lib/slideshow.py
+++ b/daida_ai/lib/slideshow.py
@@ -70,11 +70,16 @@ def configure_slideshow(
         audio_duration = _get_audio_duration_ms(slide)
 
         if has_audio_shapes:
-            if audio_duration > 0:
-                advance_ms = audio_duration + audio_buffer_ms
-            else:
-                # 外部リンク/非MP3など計測不能 → フォールバック
-                advance_ms = unmeasurable_duration_ms + audio_buffer_ms
+            raw_dur = audio_duration if audio_duration > 0 else unmeasurable_duration_ms
+            main_seq_dur_ms = max(raw_dur, 1)
+
+            # 既存アニメーション終了時刻を考慮して advance_ms を調整する。
+            # advTm は mainSeq.dur (= max(音声長, 既存アニメーション長)) + buffer 以上にする。
+            # これにより PowerPoint でも LibreOffice でも既存アニメーションが
+            # 完了する前にスライドが進むことを防ぐ。
+            existing_end = _get_existing_anim_end_ms(slide)
+            effective_dur = max(main_seq_dur_ms, existing_end)
+            advance_ms = effective_dur + audio_buffer_ms
         else:
             note_duration = _estimate_note_duration_ms(
                 slide, min_ms=silent_duration_ms
@@ -88,16 +93,10 @@ def configure_slideshow(
         # transitionを先に設定してからtimingを追加する
         _set_auto_advance(slide, advance_ms)
         if has_audio_shapes:
-            # mainSeq の dur を音声の実際の長さに設定する。
             # LibreOffice は mainSeq dur="indefinite" のままだと
             # notifySlideAnimationsEnded() が呼ばれず advTm が発火しない。
             # 音声長を dur に設定することで音声終了時にアニメーションが終わり、
             # LibreOffice のページ自動送りが正しく動作する。
-            # LibreOffice互換のため mainSeq.dur は必ず正の値にする。
-            # unmeasurable_duration_ms が 0 以下の場合でも最低 1ms を保証し、
-            # "indefinite" のまま残ることを防ぐ。
-            raw_dur = audio_duration if audio_duration > 0 else unmeasurable_duration_ms
-            main_seq_dur_ms = max(raw_dur, 1)
             _add_auto_play_animation(slide, main_seq_dur_ms=main_seq_dur_ms)
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -314,11 +313,73 @@ def _merge_audio_into_timing(
         max_id += 3  # 各audioノードはcTn idを3つ使う
 
 
+def _get_ctn_start_delay(ctn: etree._Element) -> int:
+    """cTnの開始遅延(ms)を p:stCondLst/p:cond/@delay から取得する。"""
+    st_cond = ctn.find(f"{{{_P_NS}}}stCondLst/{{{_P_NS}}}cond")
+    if st_cond is None:
+        return 0
+    delay_val = st_cond.get("delay", "0")
+    if delay_val == "indefinite":
+        return 0
+    try:
+        return int(delay_val)
+    except ValueError:
+        return 0
+
+
+def _calc_par_end_ms(par_elem: etree._Element, parent_delay: int) -> int:
+    """p:par の終了時刻(ms)を再帰的に計算する。
+
+    ネストした p:cTn の開始遅延を累積して正確な終了時刻を求める。
+    音声ノード (dur属性なし) は実質カウントされない。
+    """
+    ctn = par_elem.find(f"{{{_P_NS}}}cTn")
+    if ctn is None:
+        return parent_delay
+
+    own_delay = _get_ctn_start_delay(ctn)
+    total_delay = parent_delay + own_delay
+
+    # この cTn 自身の dur（p:seq や p:par コンテナは通常 dur="indefinite"）
+    dur_val = ctn.get("dur")
+    own_end = total_delay
+    if dur_val and dur_val != "indefinite":
+        try:
+            own_end = total_delay + int(dur_val)
+        except ValueError:
+            pass
+
+    # 子を再帰処理
+    child_tn_lst = ctn.find(f"{{{_P_NS}}}childTnLst")
+    if child_tn_lst is None:
+        return own_end
+
+    max_child_end = total_delay
+    for child in child_tn_lst:
+        if child.tag == f"{{{_P_NS}}}par":
+            # p:par はネストしたアニメーションコンテナ
+            child_end = _calc_par_end_ms(child, total_delay)
+            max_child_end = max(max_child_end, child_end)
+        else:
+            # p:anim, p:set 等の振る舞いノード: p:cBhvr > p:cTn[@dur] を探す
+            for sub_ctn in child.iter(f"{{{_P_NS}}}cTn"):
+                sub_dur = sub_ctn.get("dur")
+                if sub_dur and sub_dur != "indefinite":
+                    try:
+                        max_child_end = max(
+                            max_child_end,
+                            total_delay + _get_ctn_start_delay(sub_ctn) + int(sub_dur),
+                        )
+                    except ValueError:
+                        pass
+
+    return max(own_end, max_child_end)
+
+
 def _get_max_child_animation_dur_ms(main_seq_ctn: etree._Element) -> int:
     """mainSeq の childTnLst 内の既存アニメーション終了時刻の最大値(ms)を返す。
 
-    各 p:par の「開始遅延 + サブツリー最大dur」を計算して最大値を返す。
-    開始遅延は p:cTn/p:stCondLst/p:cond/@delay から取得する。
+    各 p:par の終了時刻を _calc_par_end_ms で再帰計算し最大値を返す。
     音声ノード (dur属性なし) は実質カウントされない。
     """
     child_tn_lst = main_seq_ctn.find(f"{{{_P_NS}}}childTnLst")
@@ -327,36 +388,19 @@ def _get_max_child_animation_dur_ms(main_seq_ctn: etree._Element) -> int:
 
     max_end = 0
     for par in child_tn_lst.findall(f"{{{_P_NS}}}par"):
-        ctn = par.find(f"{{{_P_NS}}}cTn")
-        if ctn is None:
-            continue
-
-        # 開始遅延: p:cTn/p:stCondLst/p:cond/@delay
-        start_delay = 0
-        st_cond = ctn.find(
-            f"{{{_P_NS}}}stCondLst/{{{_P_NS}}}cond"
-        )
-        if st_cond is not None:
-            delay_val = st_cond.get("delay", "0")
-            if delay_val != "indefinite":
-                try:
-                    start_delay = int(delay_val)
-                except ValueError:
-                    pass
-
-        # サブツリー内の最大 dur (音声ノードはdur属性なしのためスキップされる)
-        max_dur = 0
-        for sub_ctn in ctn.iter(f"{{{_P_NS}}}cTn"):
-            dur_val = sub_ctn.get("dur")
-            if dur_val is not None and dur_val != "indefinite":
-                try:
-                    max_dur = max(max_dur, int(dur_val))
-                except ValueError:
-                    pass
-
-        max_end = max(max_end, start_delay + max_dur)
-
+        max_end = max(max_end, _calc_par_end_ms(par, 0))
     return max_end
+
+
+def _get_existing_anim_end_ms(slide) -> int:
+    """スライドの既存アニメーション終了時刻(ms)を返す。timing がない場合は 0。"""
+    timing_elem = slide.element.find(f"{{{_P_NS}}}timing")
+    if timing_elem is None:
+        return 0
+    main_seq_ctn = timing_elem.find(f".//{{{_P_NS}}}cTn[@nodeType='mainSeq']")
+    if main_seq_ctn is None:
+        return 0
+    return _get_max_child_animation_dur_ms(main_seq_ctn)
 
 
 def _get_max_ctn_id(timing_elem: etree._Element) -> int:

--- a/daida_ai/lib/slideshow.py
+++ b/daida_ai/lib/slideshow.py
@@ -349,7 +349,16 @@ def _calc_par_end_ms(par_elem: etree._Element, parent_delay: int) -> int:
     own_end = total_delay
     if dur_val and dur_val != "indefinite":
         try:
-            own_end = total_delay + int(dur_val)
+            raw_dur = int(dur_val)
+            repeat_dur_val = ctn.get("repeatDur")
+            repeat_count_val = ctn.get("repeatCount")
+            if repeat_dur_val and repeat_dur_val != "indefinite":
+                effective_dur = int(repeat_dur_val)
+            elif repeat_count_val and repeat_count_val != "indefinite":
+                effective_dur = int(raw_dur * float(repeat_count_val))
+            else:
+                effective_dur = raw_dur
+            own_end = total_delay + effective_dur
         except ValueError:
             pass
 
@@ -428,6 +437,10 @@ def _get_max_child_animation_dur_ms(main_seq_ctn: etree._Element) -> int:
 
         if st_cond is not None:
             evt = st_cond.get("evt")
+            if evt == "onClick":
+                # クリックトリガーは無人再生では発動しないためスキップ (-1 = sentinel)
+                par_starts[idx] = -1
+                return -1
             tn_ref = st_cond.find(f"{{{_P_NS}}}tn")
             if evt in ("onEnd", "onBegin") and tn_ref is not None:
                 ref_id = tn_ref.get("val")
@@ -448,7 +461,10 @@ def _get_max_child_animation_dur_ms(main_seq_ctn: etree._Element) -> int:
 
     max_end = 0
     for i in range(len(par_list)):
-        end = get_start(i) + par_internal_durs[i]
+        start = get_start(i)
+        if start < 0:
+            continue  # onClick など無人再生でスキップされるアニメーション
+        end = start + par_internal_durs[i]
         max_end = max(max_end, end)
     return max_end
 

--- a/daida_ai/lib/slideshow.py
+++ b/daida_ai/lib/slideshow.py
@@ -278,12 +278,14 @@ def _merge_audio_into_timing(
     if main_seq_ctn is None:
         return
 
-    # LibreOffice互換: mainSeq の dur を最新の音声長で上書きする。
-    # 再実行時に短縮された音声が反映されるよう、常に上書きする（max()は使わない）。
-    # configure_slideshow は音声駆動スライドショーを前提とするため、
-    # mainSeq.dur は常に現在の音声長と一致させる。
+    # LibreOffice互換: mainSeq の dur を更新する。
+    # 比較対象は「以前のmainSeq.dur値（ステール可能性あり）」ではなく、
+    # 「childTnLst内の明示的なdur属性を持つ非音声アニメーション」にする。
+    # 音声ノードはdur属性を持たないため自然にフィルタされる。
+    # これにより: (1)再実行時に短縮された音声長が反映される (2)既存非音声アニメーションが保護される
     if main_seq_dur_ms > 0:
-        main_seq_ctn.set("dur", str(main_seq_dur_ms))
+        max_child = _get_max_child_animation_dur_ms(main_seq_ctn)
+        main_seq_ctn.set("dur", str(max(main_seq_dur_ms, max_child)))
 
     child_tn_lst = main_seq_ctn.find(f"{{{_P_NS}}}childTnLst")
     if child_tn_lst is None:
@@ -310,6 +312,26 @@ def _merge_audio_into_timing(
         audio_par = _build_audio_par_xml(shape_id, max_id + 1)
         child_tn_lst.append(audio_par)
         max_id += 3  # 各audioノードはcTn idを3つ使う
+
+
+def _get_max_child_animation_dur_ms(main_seq_ctn: etree._Element) -> int:
+    """mainSeq の childTnLst 内の既存アニメーション最大時間(ms)を返す。
+
+    音声ノード (dur属性なし) はカウントしない。
+    明示的な数値 dur を持つ cTn の最大値を返す。
+    """
+    child_tn_lst = main_seq_ctn.find(f"{{{_P_NS}}}childTnLst")
+    if child_tn_lst is None:
+        return 0
+    max_dur = 0
+    for ctn in child_tn_lst.iter(f"{{{_P_NS}}}cTn"):
+        dur_val = ctn.get("dur")
+        if dur_val is not None and dur_val != "indefinite":
+            try:
+                max_dur = max(max_dur, int(dur_val))
+            except ValueError:
+                pass
+    return max_dur
 
 
 def _get_max_ctn_id(timing_elem: etree._Element) -> int:

--- a/daida_ai/lib/slideshow.py
+++ b/daida_ai/lib/slideshow.py
@@ -88,7 +88,13 @@ def configure_slideshow(
         # transitionを先に設定してからtimingを追加する
         _set_auto_advance(slide, advance_ms)
         if has_audio_shapes:
-            _add_auto_play_animation(slide)
+            # mainSeq の dur を音声の実際の長さに設定する。
+            # LibreOffice は mainSeq dur="indefinite" のままだと
+            # notifySlideAnimationsEnded() が呼ばれず advTm が発火しない。
+            # 音声長を dur に設定することで音声終了時にアニメーションが終わり、
+            # LibreOffice のページ自動送りが正しく動作する。
+            main_seq_dur_ms = audio_duration if audio_duration > 0 else unmeasurable_duration_ms
+            _add_auto_play_animation(slide, main_seq_dur_ms=main_seq_dur_ms)
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     prs.save(str(output_path))
@@ -209,11 +215,17 @@ def _set_auto_advance(slide, advance_ms: int) -> None:
     trans.set("advTm", str(advance_ms))
 
 
-def _add_auto_play_animation(slide) -> None:
+def _add_auto_play_animation(slide, *, main_seq_dur_ms: int = 0) -> None:
     """スライドの音声シェイプに自動再生アニメーションを設定する。
 
     既存のアニメーション（テキスト・図形等）を保持しつつ、
     音声auto-playノードをmainSeqにマージする。
+
+    Args:
+        slide: python-pptxのスライドオブジェクト
+        main_seq_dur_ms: mainSeqのdur属性をミリ秒で指定（0の場合は"indefinite"）。
+            LibreOffice互換性のため音声長を渡すと、アニメーション終了が
+            notifySlideAnimationsEnded() を確実に発火させる。
 
     PowerPointのアニメーション構造:
     p:timing > p:tnLst > p:par (tmRoot) > p:childTnLst > p:seq (mainSeq) >
@@ -229,20 +241,31 @@ def _add_auto_play_animation(slide) -> None:
 
     if existing_timing is not None:
         # 既存のtiming構造にaudioノードをマージ
-        _merge_audio_into_timing(existing_timing, audio_shape_ids)
+        _merge_audio_into_timing(existing_timing, audio_shape_ids,
+                                  main_seq_dur_ms=main_seq_dur_ms)
     else:
         # timing要素がない場合は新規作成
-        timing_elem = _build_timing_xml(audio_shape_ids)
+        timing_elem = _build_timing_xml(audio_shape_ids,
+                                         main_seq_dur_ms=main_seq_dur_ms)
         _insert_slide_child(slide_elem, timing_elem)
 
 
 def _merge_audio_into_timing(
-    timing_elem: etree._Element, audio_shape_ids: list[int]
+    timing_elem: etree._Element,
+    audio_shape_ids: list[int],
+    *,
+    main_seq_dur_ms: int = 0,
 ) -> None:
     """既存のp:timing構造に音声auto-playノードを追加する。
 
     mainSeqのchildTnLstに音声用p:parを追加する。
     既存のアニメーションはそのまま保持される。
+
+    Args:
+        timing_elem: 既存の p:timing 要素
+        audio_shape_ids: 音声シェイプのIDリスト
+        main_seq_dur_ms: 0の場合は "indefinite" のまま変更しない。
+            正の値の場合は mainSeq の dur をその値（ms）に更新する。
     """
     # mainSeq (nodeType="mainSeq") を探す
     main_seq_ctn = timing_elem.find(
@@ -250,6 +273,10 @@ def _merge_audio_into_timing(
     )
     if main_seq_ctn is None:
         return
+
+    # LibreOffice互換: mainSeq の dur を音声長に更新する
+    if main_seq_dur_ms > 0:
+        main_seq_ctn.set("dur", str(main_seq_dur_ms))
 
     child_tn_lst = main_seq_ctn.find(f"{{{_P_NS}}}childTnLst")
     if child_tn_lst is None:
@@ -325,8 +352,19 @@ def _build_audio_par_xml(
     return etree.fromstring(xml)
 
 
-def _build_timing_xml(audio_shape_ids: list[int]) -> etree._Element:
-    """音声auto-play用の完全なp:timing要素を構築する。"""
+def _build_timing_xml(
+    audio_shape_ids: list[int],
+    *,
+    main_seq_dur_ms: int = 0,
+) -> etree._Element:
+    """音声auto-play用の完全なp:timing要素を構築する。
+
+    Args:
+        audio_shape_ids: 音声シェイプのIDリスト
+        main_seq_dur_ms: mainSeq の dur 属性値（ミリ秒）。
+            0 の場合は "indefinite"。正の値の場合はその値を使用する。
+            LibreOffice互換性のため音声長を渡すと自動送りが正しく動作する。
+    """
     audio_pars = ""
     ctn_id = 3
     for shape_id in audio_shape_ids:
@@ -363,13 +401,15 @@ def _build_timing_xml(audio_shape_ids: list[int]) -> etree._Element:
                 </p:par>"""
         ctn_id += 3
 
+    main_seq_dur = str(main_seq_dur_ms) if main_seq_dur_ms > 0 else "indefinite"
+
     timing_xml = f"""<p:timing xmlns:p="{_P_NS}">
   <p:tnLst>
     <p:par>
       <p:cTn id="1" dur="indefinite" restart="never" nodeType="tmRoot">
         <p:childTnLst>
           <p:seq concurrent="1" nextAc="seek">
-            <p:cTn id="2" dur="indefinite" nodeType="mainSeq">
+            <p:cTn id="2" dur="{main_seq_dur}" nodeType="mainSeq">
               <p:childTnLst>{audio_pars}
               </p:childTnLst>
             </p:cTn>

--- a/daida_ai/lib/slideshow.py
+++ b/daida_ai/lib/slideshow.py
@@ -278,18 +278,12 @@ def _merge_audio_into_timing(
     if main_seq_ctn is None:
         return
 
-    # LibreOffice互換: mainSeq の dur を音声長に更新する
-    # 既存の dur が数値の場合は大きい方を使う（非音声アニメーションのタイムラインを保護）
+    # LibreOffice互換: mainSeq の dur を最新の音声長で上書きする。
+    # 再実行時に短縮された音声が反映されるよう、常に上書きする（max()は使わない）。
+    # configure_slideshow は音声駆動スライドショーを前提とするため、
+    # mainSeq.dur は常に現在の音声長と一致させる。
     if main_seq_dur_ms > 0:
-        existing_dur = main_seq_ctn.get("dur", "indefinite")
-        if existing_dur == "indefinite":
-            new_dur = main_seq_dur_ms
-        else:
-            try:
-                new_dur = max(int(existing_dur), main_seq_dur_ms)
-            except ValueError:
-                new_dur = main_seq_dur_ms
-        main_seq_ctn.set("dur", str(new_dur))
+        main_seq_ctn.set("dur", str(main_seq_dur_ms))
 
     child_tn_lst = main_seq_ctn.find(f"{{{_P_NS}}}childTnLst")
     if child_tn_lst is None:

--- a/daida_ai/lib/slideshow.py
+++ b/daida_ai/lib/slideshow.py
@@ -279,8 +279,17 @@ def _merge_audio_into_timing(
         return
 
     # LibreOffice互換: mainSeq の dur を音声長に更新する
+    # 既存の dur が数値の場合は大きい方を使う（非音声アニメーションのタイムラインを保護）
     if main_seq_dur_ms > 0:
-        main_seq_ctn.set("dur", str(main_seq_dur_ms))
+        existing_dur = main_seq_ctn.get("dur", "indefinite")
+        if existing_dur == "indefinite":
+            new_dur = main_seq_dur_ms
+        else:
+            try:
+                new_dur = max(int(existing_dur), main_seq_dur_ms)
+            except ValueError:
+                new_dur = main_seq_dur_ms
+        main_seq_ctn.set("dur", str(new_dur))
 
     child_tn_lst = main_seq_ctn.find(f"{{{_P_NS}}}childTnLst")
     if child_tn_lst is None:

--- a/daida_ai/lib/slideshow.py
+++ b/daida_ai/lib/slideshow.py
@@ -426,15 +426,21 @@ def _get_max_child_animation_dur_ms(main_seq_ctn: etree._Element) -> int:
         own_delay = _get_ctn_start_delay(outer_ctn)
         st_cond = outer_ctn.find(f"{{{_P_NS}}}stCondLst/{{{_P_NS}}}cond")
 
-        if st_cond is not None and st_cond.get("evt") == "onEnd":
+        if st_cond is not None:
+            evt = st_cond.get("evt")
             tn_ref = st_cond.find(f"{{{_P_NS}}}tn")
-            if tn_ref is not None:
+            if evt in ("onEnd", "onBegin") and tn_ref is not None:
                 ref_id = tn_ref.get("val")
                 ref_par_idx = ctn_id_to_par_idx.get(ref_id)
                 if ref_par_idx is not None and ref_par_idx != idx:
                     ref_start = get_start(ref_par_idx)
-                    ref_end = ref_start + par_internal_durs[ref_par_idx]
-                    par_starts[idx] = ref_end + own_delay
+                    if evt == "onEnd":
+                        # After Previous: 参照アニメーション終了後に開始
+                        base = ref_start + par_internal_durs[ref_par_idx]
+                    else:
+                        # With Previous (onBegin): 参照アニメーション開始と同時
+                        base = ref_start
+                    par_starts[idx] = base + own_delay
                     return par_starts[idx]
 
         par_starts[idx] = own_delay

--- a/daida_ai/lib/slideshow.py
+++ b/daida_ai/lib/slideshow.py
@@ -381,6 +381,15 @@ def _get_max_child_animation_dur_ms(main_seq_ctn: etree._Element) -> int:
 
     各 p:par の終了時刻を _calc_par_end_ms で再帰計算し最大値を返す。
     音声ノード (dur属性なし) は実質カウントされない。
+
+    **スコープ制限**: この実装は p:stCondLst/p:cond/@delay による明示的な
+    絶対遅延を処理する。PowerPoint の "After Previous" アニメーション
+    (p:prevCondLst/p:nextCondLst または evt="onEnd" 等のイベント条件) による
+    連鎖は解析しない（依存グラフ解決が必要なため）。
+
+    daida-ai が生成するスライドには "After Previous" アニメーションは存在しない
+    ため、このツールの実用上の問題はない。外部 PPTX で複雑なアニメーション
+    チェーンが含まれる場合は、計算値が実際の終了時刻より短くなる可能性がある。
     """
     child_tn_lst = main_seq_ctn.find(f"{{{_P_NS}}}childTnLst")
     if child_tn_lst is None:

--- a/tests/test_slideshow.py
+++ b/tests/test_slideshow.py
@@ -811,3 +811,65 @@ class TestLibreOffice互換mainSeqDur:
             assert len(audio_nodes) <= 1, (
                 f"スライド {i}: audio ノードが重複してはいけない: {len(audio_nodes)} 個"
             )
+
+    def test_再実行時に短縮された音声長でmainSeq_durが縮小される(
+        self, tmp_output_dir: Path
+    ):
+        """configure_slideshow を2回実行し、2回目の音声長が短い場合に
+        mainSeq.dur がその短い値に更新されること（stale durにならない）。
+
+        LibreOffice は mainSeq.dur >= advTm でないとページ送りが発火しないため、
+        再実行後も dur <= advTm が保証されている必要がある。
+        """
+        from unittest.mock import patch
+
+        spec = SlideSpec(
+            metadata=SlideMetadata(title="T", subtitle="S", event="E"),
+            slides=[Slide(layout="title_slide", title="表紙")],
+        )
+        prs = build_presentation(spec)
+        pptx_path = tmp_output_dir / "shrink_base.pptx"
+        prs.save(str(pptx_path))
+
+        audio_dir = tmp_output_dir / "audio_shrink"
+        audio_dir.mkdir()
+        # WAV ヘッダ (non-MP3) → _get_audio_duration_ms が 0 を返す
+        # これにより unmeasurable_duration_ms がフォールバックとして使われる
+        wav_header = b"RIFF" + b"\x00" * 40
+        (audio_dir / "slide_000.mp3").write_bytes(wav_header)
+
+        out_with_audio = tmp_output_dir / "shrink_audio.pptx"
+        embed_audio_to_pptx(pptx_path, audio_dir, out_with_audio)
+
+        # 1回目: 長い unmeasurable_duration_ms (30秒) で configure
+        out_pass1 = tmp_output_dir / "shrink_pass1.pptx"
+        configure_slideshow(out_with_audio, out_pass1, unmeasurable_duration_ms=30000)
+
+        prs1 = Presentation(str(out_pass1))
+        slide1 = prs1.slides[0]
+        main_seq1 = slide1.element.find(".//p:cTn[@nodeType='mainSeq']", _ns)
+        assert main_seq1 is not None
+        dur1 = int(main_seq1.get("dur"))
+        assert dur1 >= 1
+
+        # 2回目: 短い unmeasurable_duration_ms (5秒) で再 configure
+        out_pass2 = tmp_output_dir / "shrink_pass2.pptx"
+        configure_slideshow(out_pass1, out_pass2, unmeasurable_duration_ms=5000)
+
+        prs2 = Presentation(str(out_pass2))
+        slide2 = prs2.slides[0]
+        trans2 = slide2.element.find("p:transition", _ns)
+        main_seq2 = slide2.element.find(".//p:cTn[@nodeType='mainSeq']", _ns)
+
+        assert main_seq2 is not None
+        dur2 = int(main_seq2.get("dur"))
+        adv_tm2 = int(trans2.get("advTm"))
+
+        # 短い音声長で上書きされていること
+        assert dur2 < dur1, (
+            f"2回目の短い音声長({5000}ms)で dur が縮小されるべき: "
+            f"pass1={dur1}ms, pass2={dur2}ms"
+        )
+        assert dur2 <= adv_tm2, (
+            f"mainSeq dur({dur2}ms) は advTm({adv_tm2}ms) 以下であるべき"
+        )

--- a/tests/test_slideshow.py
+++ b/tests/test_slideshow.py
@@ -1238,15 +1238,13 @@ class TestLibreOffice互換mainSeqDur:
             f"mainSeq.dur({dur}ms) は既存アニメーション(5000ms)以上であるべき"
         )
 
-    def test_既知制限_onEndイベント連鎖アニメーションの合計は計算されない(
+    def test_onEndイベント連鎖アニメーションの合計時間が計算される(
         self, tmp_output_dir: Path
     ):
-        """[既知の制限] "After Previous" (evt="onEnd") による連鎖アニメーションの
-        合計時間は計算されない。各エフェクトの最大時間のみが考慮される。
+        """"After Previous" (evt="onEnd") による連鎖アニメーションの
+        合計時間が正しく計算されることを確認する。
 
-        daida-ai は "After Previous" アニメーションを生成しないため実用上問題なし。
-        外部 PPTX を configure_slideshow に渡す場合は、連鎖アニメーションの
-        合計が正確に計算されないことに注意。
+        anim1(dur=1000ms) → anim2(onEnd→anim1, dur=2000ms) = 合計3000ms
         """
         from lxml import etree
 
@@ -1346,10 +1344,84 @@ class TestLibreOffice互換mainSeqDur:
         assert main_seq is not None
         dur = int(main_seq.get("dur"))
 
-        # [既知制限] onEnd チェーンの合計(3000ms)は計算されず、最大値(2000ms)が使われる
-        # daida-ai は onEnd チェーンを生成しないため実用上は問題なし
-        assert dur >= 2000, (
-            f"mainSeq.dur({dur}ms) は少なくとも最大エフェクト長(2000ms)以上であるべき"
+        # onEnd チェーンの合計: anim1(1000ms) + anim2(onEnd→anim1, 2000ms) = 3000ms
+        assert dur >= 3000, (
+            f"mainSeq.dur({dur}ms) は onEnd チェーン合計(1000+2000=3000ms)以上であるべき"
         )
-        # 合計3000msが計算されないことは既知の制限 — これが変わった場合テストを更新する
-        # (3000ms以上であれば改善されたことを示す)
+
+    def test_音声なしスライドでも既存アニメーション長がadvTmに反映される(
+        self, tmp_output_dir: Path
+    ):
+        """音声なしスライドに既存アニメーション(5000ms)がある場合、
+        advTm >= 5000ms + buffer になることを確認する。
+        """
+        from lxml import etree
+
+        _P = "http://schemas.openxmlformats.org/presentationml/2006/main"
+
+        spec = SlideSpec(
+            metadata=SlideMetadata(title="LT", subtitle="S", event="E"),
+            slides=[
+                Slide(layout="title_slide", title="表紙"),
+                Slide(layout="title_and_content", title="内容", body=["a"]),
+            ],
+        )
+        prs = build_presentation(spec)
+        pptx_path = tmp_output_dir / "silent_anim_base.pptx"
+        prs.save(str(pptx_path))
+
+        # 音声なし、スライド1に5000msのアニメーションを注入
+        prs2 = Presentation(str(pptx_path))
+        slide = prs2.slides[1]
+        timing_xml = f"""<p:timing xmlns:p="{_P}">
+  <p:tnLst>
+    <p:par>
+      <p:cTn id="1" dur="indefinite" restart="never" nodeType="tmRoot">
+        <p:childTnLst>
+          <p:seq concurrent="1" nextAc="seek">
+            <p:cTn id="2" dur="indefinite" nodeType="mainSeq">
+              <p:childTnLst>
+                <p:par>
+                  <p:cTn id="3" fill="hold">
+                    <p:stCondLst><p:cond delay="0"/></p:stCondLst>
+                    <p:childTnLst>
+                      <p:par>
+                        <p:cTn id="4" dur="5000" fill="hold">
+                          <p:childTnLst>
+                            <p:anim calcmode="lin" valueType="num">
+                              <p:cBhvr>
+                                <p:cTn id="5" dur="5000" fill="hold"/>
+                                <p:tgtEl><p:spTgt spid="2"/></p:tgtEl>
+                                <p:attrNameLst><p:attrName>style.opacity</p:attrName></p:attrNameLst>
+                              </p:cBhvr>
+                            </p:anim>
+                          </p:childTnLst>
+                        </p:cTn>
+                      </p:par>
+                    </p:childTnLst>
+                  </p:cTn>
+                </p:par>
+              </p:childTnLst>
+            </p:cTn>
+          </p:seq>
+        </p:childTnLst>
+      </p:cTn>
+    </p:par>
+  </p:tnLst>
+</p:timing>"""
+        slide.element.append(etree.fromstring(timing_xml))
+        with_anim = tmp_output_dir / "silent_anim_with.pptx"
+        prs2.save(str(with_anim))
+
+        out = tmp_output_dir / "silent_anim_out.pptx"
+        configure_slideshow(with_anim, out)
+
+        prs3 = Presentation(str(out))
+        slide_out = prs3.slides[1]
+        trans = slide_out.element.find("p:transition", _ns)
+        adv_tm = int(trans.get("advTm"))
+
+        # 音声なしスライドでも既存アニメーション(5000ms) + buffer(1000ms) = 6000ms 以上
+        assert adv_tm >= 5000 + 1000, (
+            f"advTm({adv_tm}ms) は 既存アニメーション(5000ms) + buffer(1000ms) 以上であるべき"
+        )

--- a/tests/test_slideshow.py
+++ b/tests/test_slideshow.py
@@ -1425,3 +1425,121 @@ class TestLibreOffice互換mainSeqDur:
         assert adv_tm >= 5000 + 1000, (
             f"advTm({adv_tm}ms) は 既存アニメーション(5000ms) + buffer(1000ms) 以上であるべき"
         )
+
+    def test_onBeginイベントの同時再生アニメーションで長い方がtimelineに反映される(
+        self, tmp_output_dir: Path
+    ):
+        """"With Previous" (evt="onBegin") による同時再生アニメーションの場合、
+        開始時刻が参照アニメーションと同じになり、長い方の終了時刻が採用される。
+
+        animA: delay=3000ms, dur=1000ms → 終了=4000ms
+        animB: onBegin→animA, dur=7000ms → 開始=3000ms, 終了=10000ms
+        mainSeq.dur >= 10000ms であるべき
+        """
+        from lxml import etree
+
+        _P = "http://schemas.openxmlformats.org/presentationml/2006/main"
+
+        spec = SlideSpec(
+            metadata=SlideMetadata(title="LT", subtitle="S", event="E"),
+            slides=[
+                Slide(layout="title_slide", title="表紙"),
+                Slide(layout="title_and_content", title="内容", body=["a"]),
+            ],
+        )
+        prs = build_presentation(spec)
+        pptx_path = tmp_output_dir / "onbegin_base.pptx"
+        prs.save(str(pptx_path))
+
+        audio_dir = tmp_output_dir / "audio_onbegin"
+        audio_dir.mkdir()
+        dummy_mp3 = b"\xff\xfb\x90\x00" + b"\x00" * 100
+        (audio_dir / "slide_001.mp3").write_bytes(dummy_mp3)
+        with_audio = tmp_output_dir / "onbegin_audio.pptx"
+        embed_audio_to_pptx(pptx_path, audio_dir, with_audio)
+
+        prs2 = Presentation(str(with_audio))
+        slide = prs2.slides[1]
+        # animA: delay=3000, dur=1000 (終了=4000ms)
+        # animB: onBegin→animA (id=4), dur=7000 (開始=3000, 終了=10000ms)
+        timing_xml = f"""<p:timing xmlns:p="{_P}">
+  <p:tnLst>
+    <p:par>
+      <p:cTn id="1" dur="indefinite" restart="never" nodeType="tmRoot">
+        <p:childTnLst>
+          <p:seq concurrent="1" nextAc="seek">
+            <p:cTn id="2" dur="indefinite" nodeType="mainSeq">
+              <p:childTnLst>
+                <p:par>
+                  <p:cTn id="3" fill="hold">
+                    <p:stCondLst><p:cond delay="3000"/></p:stCondLst>
+                    <p:childTnLst>
+                      <p:par>
+                        <p:cTn id="4" dur="1000" fill="hold">
+                          <p:childTnLst>
+                            <p:anim calcmode="lin" valueType="num">
+                              <p:cBhvr>
+                                <p:cTn id="5" dur="1000" fill="hold"/>
+                                <p:tgtEl><p:spTgt spid="2"/></p:tgtEl>
+                                <p:attrNameLst><p:attrName>style.opacity</p:attrName></p:attrNameLst>
+                              </p:cBhvr>
+                            </p:anim>
+                          </p:childTnLst>
+                        </p:cTn>
+                      </p:par>
+                    </p:childTnLst>
+                  </p:cTn>
+                </p:par>
+                <p:par>
+                  <p:cTn id="6" fill="hold">
+                    <p:stCondLst>
+                      <p:cond delay="0" evt="onBegin"><p:tn val="4"/></p:cond>
+                    </p:stCondLst>
+                    <p:childTnLst>
+                      <p:par>
+                        <p:cTn id="7" dur="7000" fill="hold">
+                          <p:childTnLst>
+                            <p:anim calcmode="lin" valueType="num">
+                              <p:cBhvr>
+                                <p:cTn id="8" dur="7000" fill="hold"/>
+                                <p:tgtEl><p:spTgt spid="2"/></p:tgtEl>
+                                <p:attrNameLst><p:attrName>ppt.y</p:attrName></p:attrNameLst>
+                              </p:cBhvr>
+                            </p:anim>
+                          </p:childTnLst>
+                        </p:cTn>
+                      </p:par>
+                    </p:childTnLst>
+                  </p:cTn>
+                </p:par>
+              </p:childTnLst>
+            </p:cTn>
+          </p:seq>
+        </p:childTnLst>
+      </p:cTn>
+    </p:par>
+  </p:tnLst>
+</p:timing>"""
+        slide.element.append(etree.fromstring(timing_xml))
+        with_existing = tmp_output_dir / "onbegin_existing.pptx"
+        prs2.save(str(with_existing))
+
+        out = tmp_output_dir / "onbegin_out.pptx"
+        configure_slideshow(with_existing, out)
+
+        prs3 = Presentation(str(out))
+        slide_out = prs3.slides[1]
+        trans = slide_out.element.find("p:transition", _ns)
+        main_seq = slide_out.element.find(".//p:cTn[@nodeType='mainSeq']", _ns)
+
+        assert main_seq is not None
+        dur = int(main_seq.get("dur"))
+        adv_tm = int(trans.get("advTm"))
+
+        # animA終了=4000ms, animB終了=3000+7000=10000ms → max=10000ms
+        assert dur >= 10000, (
+            f"mainSeq.dur({dur}ms) は animB終了時刻(3000+7000=10000ms)以上であるべき"
+        )
+        assert adv_tm >= 10000, (
+            f"advTm({adv_tm}ms) は 10000ms + buffer 以上であるべき"
+        )

--- a/tests/test_slideshow.py
+++ b/tests/test_slideshow.py
@@ -1629,7 +1629,13 @@ class TestLibreOffice互換mainSeqDur:
         assert main_seq is not None
         adv_tm = int(trans.get("advTm"))
 
-        # dur=1000 * repeatCount=3 = 3000ms → advTm >= 3000ms
+        # dur=1000 * repeatCount=3 = 3000ms → advTm >= 3000ms, mainSeq.dur >= 3000ms
+        main_seq = slide_out.element.find(".//p:cTn[@nodeType='mainSeq']", _ns)
+        assert main_seq is not None
+        dur = int(main_seq.get("dur"))
+        assert dur >= 3000, (
+            f"mainSeq.dur({dur}ms) は repeatCount=3 * dur=1000ms = 3000ms 以上であるべき"
+        )
         assert adv_tm >= 3000, (
             f"advTm({adv_tm}ms) は repeatCount=3 * dur=1000ms = 3000ms 以上であるべき"
         )
@@ -1719,7 +1725,310 @@ class TestLibreOffice互換mainSeqDur:
 
         adv_tm = int(trans.get("advTm"))
 
-        # onClick アニメーション(10000ms)は無視されるため、advTm << 10000ms
+        # onClick アニメーション(10000ms)は無視されるため、advTm は音声ベースで << 10000ms
+        # 音声は dummy_mp3 (数ms) + silent_duration_ms のデフォルト(5000ms) + buffer(1000ms)
+        # → advTm < 10000ms であること
         assert adv_tm < 10000, (
             f"advTm({adv_tm}ms) は onClick アニメーション(10000ms)の影響を受けてはいけない"
         )
+        # また advTm は正の値であること（スライドが進むこと）
+        assert adv_tm > 0, f"advTm({adv_tm}ms) は正の値であるべき"
+
+    def test_repeatDurアニメーションで総時間がtimelineに反映される(
+        self, tmp_output_dir: Path
+    ):
+        """repeatDur="2000" (総時間2000ms上限) のアニメーションで advTm >= 2000ms になること。
+
+        ECMA-376では repeatDur は繰り返し総時間の上限を指定する。
+        """
+        from lxml import etree
+
+        _P = "http://schemas.openxmlformats.org/presentationml/2006/main"
+
+        spec = SlideSpec(
+            metadata=SlideMetadata(title="LT", subtitle="S", event="E"),
+            slides=[
+                Slide(layout="title_slide", title="表紙"),
+                Slide(layout="title_and_content", title="内容", body=["a"]),
+            ],
+        )
+        prs = build_presentation(spec)
+        pptx_path = tmp_output_dir / "repeatdur_base.pptx"
+        prs.save(str(pptx_path))
+
+        audio_dir = tmp_output_dir / "audio_repeatdur"
+        audio_dir.mkdir()
+        dummy_mp3 = b"\xff\xfb\x90\x00" + b"\x00" * 100
+        (audio_dir / "slide_001.mp3").write_bytes(dummy_mp3)
+        with_audio = tmp_output_dir / "repeatdur_audio.pptx"
+        embed_audio_to_pptx(pptx_path, audio_dir, with_audio)
+
+        # dur=500ms を repeatDur=2000ms で繰り返す → 実効2000ms
+        prs2 = Presentation(str(with_audio))
+        slide = prs2.slides[1]
+        timing_xml = f"""<p:timing xmlns:p="{_P}">
+  <p:tnLst>
+    <p:par>
+      <p:cTn id="1" dur="indefinite" restart="never" nodeType="tmRoot">
+        <p:childTnLst>
+          <p:seq concurrent="1" nextAc="seek">
+            <p:cTn id="2" dur="indefinite" nodeType="mainSeq">
+              <p:childTnLst>
+                <p:par>
+                  <p:cTn id="3" fill="hold">
+                    <p:stCondLst><p:cond delay="0"/></p:stCondLst>
+                    <p:childTnLst>
+                      <p:par>
+                        <p:cTn id="4" dur="500" repeatDur="2000" fill="hold">
+                          <p:stCondLst><p:cond delay="0"/></p:stCondLst>
+                          <p:childTnLst>
+                            <p:anim calcmode="lin" valueType="num">
+                              <p:cBhvr>
+                                <p:cTn id="5" dur="500" fill="hold"/>
+                                <p:tgtEl><p:spTgt spid="2"/></p:tgtEl>
+                                <p:attrNameLst><p:attrName>style.opacity</p:attrName></p:attrNameLst>
+                              </p:cBhvr>
+                            </p:anim>
+                          </p:childTnLst>
+                        </p:cTn>
+                      </p:par>
+                    </p:childTnLst>
+                  </p:cTn>
+                </p:par>
+              </p:childTnLst>
+            </p:cTn>
+          </p:seq>
+        </p:childTnLst>
+      </p:cTn>
+    </p:par>
+  </p:tnLst>
+</p:timing>"""
+        slide.element.append(etree.fromstring(timing_xml))
+        with_existing = tmp_output_dir / "repeatdur_existing.pptx"
+        prs2.save(str(with_existing))
+
+        out = tmp_output_dir / "repeatdur_out.pptx"
+        configure_slideshow(with_existing, out)
+
+        prs3 = Presentation(str(out))
+        slide_out = prs3.slides[1]
+        trans = slide_out.element.find("p:transition", _ns)
+        adv_tm = int(trans.get("advTm"))
+
+        # repeatDur=2000ms → advTm >= 2000ms
+        assert adv_tm >= 2000, (
+            f"advTm({adv_tm}ms) は repeatDur=2000ms 以上であるべき"
+        )
+
+    def test_repeatCount_indefiniteは通常のdurとして扱われる(
+        self, tmp_output_dir: Path
+    ):
+        """repeatCount="indefinite" は繰り返し無限大 → タイムライン計算では dur のみを使う。
+
+        advTm は repeatCount=indefinite のアニメーション長 (dur=1000ms) + buffer が下限になる。
+        """
+        from lxml import etree
+
+        _P = "http://schemas.openxmlformats.org/presentationml/2006/main"
+
+        spec = SlideSpec(
+            metadata=SlideMetadata(title="LT", subtitle="S", event="E"),
+            slides=[
+                Slide(layout="title_slide", title="表紙"),
+                Slide(layout="title_and_content", title="内容", body=["a"]),
+            ],
+        )
+        prs = build_presentation(spec)
+        pptx_path = tmp_output_dir / "repeat_indef_base.pptx"
+        prs.save(str(pptx_path))
+
+        audio_dir = tmp_output_dir / "audio_repeat_indef"
+        audio_dir.mkdir()
+        dummy_mp3 = b"\xff\xfb\x90\x00" + b"\x00" * 100
+        (audio_dir / "slide_001.mp3").write_bytes(dummy_mp3)
+        with_audio = tmp_output_dir / "repeat_indef_audio.pptx"
+        embed_audio_to_pptx(pptx_path, audio_dir, with_audio)
+
+        # repeatCount="indefinite" + dur="1000" → advTm は有限値になること
+        prs2 = Presentation(str(with_audio))
+        slide = prs2.slides[1]
+        timing_xml = f"""<p:timing xmlns:p="{_P}">
+  <p:tnLst>
+    <p:par>
+      <p:cTn id="1" dur="indefinite" restart="never" nodeType="tmRoot">
+        <p:childTnLst>
+          <p:seq concurrent="1" nextAc="seek">
+            <p:cTn id="2" dur="indefinite" nodeType="mainSeq">
+              <p:childTnLst>
+                <p:par>
+                  <p:cTn id="3" fill="hold">
+                    <p:stCondLst><p:cond delay="0"/></p:stCondLst>
+                    <p:childTnLst>
+                      <p:par>
+                        <p:cTn id="4" dur="1000" repeatCount="indefinite" fill="hold">
+                          <p:stCondLst><p:cond delay="0"/></p:stCondLst>
+                          <p:childTnLst>
+                            <p:anim calcmode="lin" valueType="num">
+                              <p:cBhvr>
+                                <p:cTn id="5" dur="1000" fill="hold"/>
+                                <p:tgtEl><p:spTgt spid="2"/></p:tgtEl>
+                                <p:attrNameLst><p:attrName>style.opacity</p:attrName></p:attrNameLst>
+                              </p:cBhvr>
+                            </p:anim>
+                          </p:childTnLst>
+                        </p:cTn>
+                      </p:par>
+                    </p:childTnLst>
+                  </p:cTn>
+                </p:par>
+              </p:childTnLst>
+            </p:cTn>
+          </p:seq>
+        </p:childTnLst>
+      </p:cTn>
+    </p:par>
+  </p:tnLst>
+</p:timing>"""
+        slide.element.append(etree.fromstring(timing_xml))
+        with_existing = tmp_output_dir / "repeat_indef_existing.pptx"
+        prs2.save(str(with_existing))
+
+        out = tmp_output_dir / "repeat_indef_out.pptx"
+        configure_slideshow(with_existing, out)
+
+        prs3 = Presentation(str(out))
+        slide_out = prs3.slides[1]
+        trans = slide_out.element.find("p:transition", _ns)
+        adv_tm = int(trans.get("advTm"))
+
+        # repeatCount="indefinite" はスキップ → dur=1000ms のみ考慮 → advTm は有限の正の値
+        assert adv_tm > 0, f"advTm({adv_tm}ms) は正の値であるべき"
+        # advTm は "indefinite" のせいで無限大にはならない（int 変換できる）
+        assert adv_tm < 10_000_000, f"advTm({adv_tm}ms) が過大すぎる"
+
+    def test_onEnd循環参照でRecursionErrorが発生しない(
+        self, tmp_output_dir: Path
+    ):
+        """anim1 onEnd→anim2, anim2 onEnd→anim1 の循環参照でクラッシュしないこと。
+
+        configure_slideshow が完了し、advTm が有限の正の値になることを確認する。
+        """
+        from lxml import etree
+
+        _P = "http://schemas.openxmlformats.org/presentationml/2006/main"
+
+        spec = SlideSpec(
+            metadata=SlideMetadata(title="LT", subtitle="S", event="E"),
+            slides=[
+                Slide(layout="title_slide", title="表紙"),
+                Slide(layout="title_and_content", title="内容", body=["a"]),
+            ],
+        )
+        prs = build_presentation(spec)
+        pptx_path = tmp_output_dir / "cycle_base.pptx"
+        prs.save(str(pptx_path))
+
+        audio_dir = tmp_output_dir / "audio_cycle"
+        audio_dir.mkdir()
+        dummy_mp3 = b"\xff\xfb\x90\x00" + b"\x00" * 100
+        (audio_dir / "slide_001.mp3").write_bytes(dummy_mp3)
+        with_audio = tmp_output_dir / "cycle_audio.pptx"
+        embed_audio_to_pptx(pptx_path, audio_dir, with_audio)
+
+        # par1 (id=3, cTn id=4) onEnd→ par2 (cTn id=6)
+        # par2 (id=6) onEnd→ par1 (cTn id=4) — 循環
+        prs2 = Presentation(str(with_audio))
+        slide = prs2.slides[1]
+        timing_xml = f"""<p:timing xmlns:p="{_P}">
+  <p:tnLst>
+    <p:par>
+      <p:cTn id="1" dur="indefinite" restart="never" nodeType="tmRoot">
+        <p:childTnLst>
+          <p:seq concurrent="1" nextAc="seek">
+            <p:cTn id="2" dur="indefinite" nodeType="mainSeq">
+              <p:childTnLst>
+                <p:par>
+                  <p:cTn id="3" fill="hold">
+                    <p:stCondLst><p:cond delay="0"/></p:stCondLst>
+                    <p:childTnLst>
+                      <p:par>
+                        <p:cTn id="4" dur="1000" fill="hold">
+                          <p:childTnLst>
+                            <p:anim calcmode="lin" valueType="num">
+                              <p:cBhvr>
+                                <p:cTn id="5" dur="1000" fill="hold"/>
+                                <p:tgtEl><p:spTgt spid="2"/></p:tgtEl>
+                                <p:attrNameLst><p:attrName>style.opacity</p:attrName></p:attrNameLst>
+                              </p:cBhvr>
+                            </p:anim>
+                          </p:childTnLst>
+                        </p:cTn>
+                      </p:par>
+                    </p:childTnLst>
+                  </p:cTn>
+                </p:par>
+                <p:par>
+                  <p:cTn id="6" fill="hold">
+                    <p:stCondLst>
+                      <p:cond delay="0" evt="onEnd"><p:tn val="4"/></p:cond>
+                    </p:stCondLst>
+                    <p:childTnLst>
+                      <p:par>
+                        <p:cTn id="7" dur="2000" fill="hold">
+                          <p:childTnLst>
+                            <p:anim calcmode="lin" valueType="num">
+                              <p:cBhvr>
+                                <p:cTn id="8" dur="2000" fill="hold"/>
+                                <p:tgtEl><p:spTgt spid="2"/></p:tgtEl>
+                                <p:attrNameLst><p:attrName>style.opacity</p:attrName></p:attrNameLst>
+                              </p:cBhvr>
+                            </p:anim>
+                          </p:childTnLst>
+                        </p:cTn>
+                      </p:par>
+                    </p:childTnLst>
+                  </p:cTn>
+                </p:par>
+                <p:par>
+                  <p:cTn id="9" fill="hold">
+                    <p:stCondLst>
+                      <p:cond delay="0" evt="onEnd"><p:tn val="6"/></p:cond>
+                    </p:stCondLst>
+                    <p:childTnLst>
+                      <p:par>
+                        <p:cTn id="10" dur="500" fill="hold">
+                          <p:childTnLst>
+                            <p:anim calcmode="lin" valueType="num">
+                              <p:cBhvr>
+                                <p:cTn id="11" dur="500" fill="hold"/>
+                                <p:tgtEl><p:spTgt spid="3"/></p:tgtEl>
+                                <p:attrNameLst><p:attrName>style.opacity</p:attrName></p:attrNameLst>
+                              </p:cBhvr>
+                            </p:anim>
+                          </p:childTnLst>
+                        </p:cTn>
+                      </p:par>
+                    </p:childTnLst>
+                  </p:cTn>
+                </p:par>
+              </p:childTnLst>
+            </p:cTn>
+          </p:seq>
+        </p:childTnLst>
+      </p:cTn>
+    </p:par>
+  </p:tnLst>
+</p:timing>"""
+        slide.element.append(etree.fromstring(timing_xml))
+        with_existing = tmp_output_dir / "cycle_existing.pptx"
+        prs2.save(str(with_existing))
+
+        out = tmp_output_dir / "cycle_out.pptx"
+        # RecursionError を発生させずに完了すること
+        configure_slideshow(with_existing, out)
+
+        prs3 = Presentation(str(out))
+        slide_out = prs3.slides[1]
+        trans = slide_out.element.find("p:transition", _ns)
+        adv_tm = int(trans.get("advTm"))
+        assert adv_tm > 0, f"循環参照があっても advTm は正の値であるべき: {adv_tm}"

--- a/tests/test_slideshow.py
+++ b/tests/test_slideshow.py
@@ -708,3 +708,39 @@ class TestLibreOffice互換mainSeqDur:
         assert dur <= adv_tm, (
             f"mainSeq dur({dur}ms) は advTm({adv_tm}ms) 以下であるべき"
         )
+
+    def test_既存timingがある場合もmainSeq_durが更新される(
+        self, pptx_with_audio: Path, tmp_output_dir: Path
+    ):
+        """configure_slideshow を2回適用しても mainSeq.dur が正しく更新される。
+
+        実際のデッキでは既存の p:timing を持つスライドがある。
+        _merge_audio_into_timing パスで mainSeq.dur が上書きされることを確認する。
+        """
+        # 1回目: timing が新規作成される
+        output1 = tmp_output_dir / "show_lo_pass1.pptx"
+        configure_slideshow(pptx_with_audio, output1)
+
+        # 2回目: 既存 timing を持つスライドに対して _merge_audio_into_timing が呼ばれる
+        output2 = tmp_output_dir / "show_lo_pass2.pptx"
+        configure_slideshow(output1, output2)
+
+        prs = Presentation(str(output2))
+        slide = prs.slides[1]  # 音声ありスライド (index 1)
+
+        main_seq_ctn = slide.element.find(".//p:cTn[@nodeType='mainSeq']", _ns)
+        assert main_seq_ctn is not None, "mainSeq p:cTn が存在すること"
+
+        dur = main_seq_ctn.get("dur")
+        assert dur != "indefinite", (
+            f"_merge_audio_into_timing 経由でも dur が 'indefinite' のまま残ってはいけない: {dur}"
+        )
+        assert dur is not None and int(dur) > 0, (
+            f"dur は正の整数(ms)であること: {dur}"
+        )
+
+        # 既存アニメーションノードが重複していないことも確認
+        audio_nodes = slide.element.findall(".//p:audio", _ns)
+        assert len(audio_nodes) == 1, (
+            f"2回適用しても audio ノードは1つだけであるべき: {len(audio_nodes)} 個"
+        )

--- a/tests/test_slideshow.py
+++ b/tests/test_slideshow.py
@@ -873,3 +873,94 @@ class TestLibreOffice互換mainSeqDur:
         assert dur2 <= adv_tm2, (
             f"mainSeq dur({dur2}ms) は advTm({adv_tm2}ms) 以下であるべき"
         )
+
+    def test_既存非音声アニメーションより短い音声でもtimeline保護される(
+        self, tmp_output_dir: Path
+    ):
+        """音声長 < 既存アニメーションdur のとき、mainSeq.dur は既存アニメーション長以上になる。
+
+        音声(6ms)より長い非音声アニメーション(500ms)が存在する場合、
+        mainSeq.dur が 500ms 以上になることで既存アニメーションが切り詰められない。
+        """
+        from lxml import etree
+
+        _P = "http://schemas.openxmlformats.org/presentationml/2006/main"
+
+        spec = SlideSpec(
+            metadata=SlideMetadata(title="LT", subtitle="S", event="E"),
+            slides=[
+                Slide(layout="title_slide", title="表紙"),
+                Slide(layout="title_and_content", title="内容", body=["a"]),
+            ],
+        )
+        prs = build_presentation(spec)
+        pptx_path = tmp_output_dir / "anim_protect_base.pptx"
+        prs.save(str(pptx_path))
+
+        audio_dir = tmp_output_dir / "audio_anim_protect"
+        audio_dir.mkdir()
+        # 約6msのフェイクMP3 (音声長 < 500ms)
+        dummy_mp3 = b"\xff\xfb\x90\x00" + b"\x00" * 100
+        (audio_dir / "slide_001.mp3").write_bytes(dummy_mp3)
+        with_audio = tmp_output_dir / "anim_protect_audio.pptx"
+        embed_audio_to_pptx(pptx_path, audio_dir, with_audio)
+
+        # スライド1に500msの非音声アニメーションを注入
+        prs2 = Presentation(str(with_audio))
+        slide = prs2.slides[1]
+        timing_xml = f"""<p:timing xmlns:p="{_P}">
+  <p:tnLst>
+    <p:par>
+      <p:cTn id="1" dur="indefinite" restart="never" nodeType="tmRoot">
+        <p:childTnLst>
+          <p:seq concurrent="1" nextAc="seek">
+            <p:cTn id="2" dur="indefinite" nodeType="mainSeq">
+              <p:childTnLst>
+                <p:par>
+                  <p:cTn id="3" fill="hold">
+                    <p:stCondLst><p:cond delay="0"/></p:stCondLst>
+                    <p:childTnLst>
+                      <p:par>
+                        <p:cTn id="4" fill="hold">
+                          <p:stCondLst><p:cond delay="0"/></p:stCondLst>
+                          <p:childTnLst>
+                            <p:anim calcmode="lin" valueType="num">
+                              <p:cBhvr>
+                                <p:cTn id="5" dur="500" fill="hold"/>
+                                <p:tgtEl><p:spTgt spid="2"/></p:tgtEl>
+                                <p:attrNameLst><p:attrName>style.opacity</p:attrName></p:attrNameLst>
+                              </p:cBhvr>
+                            </p:anim>
+                          </p:childTnLst>
+                        </p:cTn>
+                      </p:par>
+                    </p:childTnLst>
+                  </p:cTn>
+                </p:par>
+              </p:childTnLst>
+            </p:cTn>
+          </p:seq>
+        </p:childTnLst>
+      </p:cTn>
+    </p:par>
+  </p:tnLst>
+</p:timing>"""
+        slide.element.append(etree.fromstring(timing_xml))
+        with_existing = tmp_output_dir / "anim_protect_existing.pptx"
+        prs2.save(str(with_existing))
+
+        out = tmp_output_dir / "anim_protect_out.pptx"
+        configure_slideshow(with_existing, out)
+
+        prs3 = Presentation(str(out))
+        slide_out = prs3.slides[1]
+        main_seq = slide_out.element.find(".//p:cTn[@nodeType='mainSeq']", _ns)
+        assert main_seq is not None
+
+        dur = int(main_seq.get("dur"))
+        assert dur >= 500, (
+            f"mainSeq.dur({dur}ms) は既存アニメーション(500ms)以上であるべき"
+        )
+        assert main_seq.get("dur") != "indefinite", (
+            "mainSeq.dur は 'indefinite' のまま残ってはいけない"
+        )

--- a/tests/test_slideshow.py
+++ b/tests/test_slideshow.py
@@ -1543,3 +1543,183 @@ class TestLibreOffice互換mainSeqDur:
         assert adv_tm >= 10000, (
             f"advTm({adv_tm}ms) は 10000ms + buffer 以上であるべき"
         )
+
+    def test_repeatCountアニメーションで繰り返し時間がtimelineに反映される(
+        self, tmp_output_dir: Path
+    ):
+        """repeatCount="3" + dur="1000" のアニメーションは実効3000msとして計算されること。
+
+        単純にdur=1000msとして計算すると advTm が短すぎてアニメーション完了前にスライドが進む。
+        """
+        from lxml import etree
+
+        _P = "http://schemas.openxmlformats.org/presentationml/2006/main"
+
+        spec = SlideSpec(
+            metadata=SlideMetadata(title="LT", subtitle="S", event="E"),
+            slides=[
+                Slide(layout="title_slide", title="表紙"),
+                Slide(layout="title_and_content", title="内容", body=["a"]),
+            ],
+        )
+        prs = build_presentation(spec)
+        pptx_path = tmp_output_dir / "repeat_base.pptx"
+        prs.save(str(pptx_path))
+
+        audio_dir = tmp_output_dir / "audio_repeat"
+        audio_dir.mkdir()
+        # 音声長 << 3000ms
+        dummy_mp3 = b"\xff\xfb\x90\x00" + b"\x00" * 100
+        (audio_dir / "slide_001.mp3").write_bytes(dummy_mp3)
+        with_audio = tmp_output_dir / "repeat_audio.pptx"
+        embed_audio_to_pptx(pptx_path, audio_dir, with_audio)
+
+        # repeatCount="3" + dur="1000" → 実効3000ms
+        prs2 = Presentation(str(with_audio))
+        slide = prs2.slides[1]
+        timing_xml = f"""<p:timing xmlns:p="{_P}">
+  <p:tnLst>
+    <p:par>
+      <p:cTn id="1" dur="indefinite" restart="never" nodeType="tmRoot">
+        <p:childTnLst>
+          <p:seq concurrent="1" nextAc="seek">
+            <p:cTn id="2" dur="indefinite" nodeType="mainSeq">
+              <p:childTnLst>
+                <p:par>
+                  <p:cTn id="3" fill="hold">
+                    <p:stCondLst><p:cond delay="0"/></p:stCondLst>
+                    <p:childTnLst>
+                      <p:par>
+                        <p:cTn id="4" dur="1000" repeatCount="3" fill="hold">
+                          <p:stCondLst><p:cond delay="0"/></p:stCondLst>
+                          <p:childTnLst>
+                            <p:anim calcmode="lin" valueType="num">
+                              <p:cBhvr>
+                                <p:cTn id="5" dur="1000" fill="hold"/>
+                                <p:tgtEl><p:spTgt spid="2"/></p:tgtEl>
+                                <p:attrNameLst><p:attrName>style.opacity</p:attrName></p:attrNameLst>
+                              </p:cBhvr>
+                            </p:anim>
+                          </p:childTnLst>
+                        </p:cTn>
+                      </p:par>
+                    </p:childTnLst>
+                  </p:cTn>
+                </p:par>
+              </p:childTnLst>
+            </p:cTn>
+          </p:seq>
+        </p:childTnLst>
+      </p:cTn>
+    </p:par>
+  </p:tnLst>
+</p:timing>"""
+        slide.element.append(etree.fromstring(timing_xml))
+        with_existing = tmp_output_dir / "repeat_existing.pptx"
+        prs2.save(str(with_existing))
+
+        out = tmp_output_dir / "repeat_out.pptx"
+        configure_slideshow(with_existing, out)
+
+        prs3 = Presentation(str(out))
+        slide_out = prs3.slides[1]
+        trans = slide_out.element.find("p:transition", _ns)
+        main_seq = slide_out.element.find(".//p:cTn[@nodeType='mainSeq']", _ns)
+
+        assert main_seq is not None
+        adv_tm = int(trans.get("advTm"))
+
+        # dur=1000 * repeatCount=3 = 3000ms → advTm >= 3000ms
+        assert adv_tm >= 3000, (
+            f"advTm({adv_tm}ms) は repeatCount=3 * dur=1000ms = 3000ms 以上であるべき"
+        )
+
+    def test_onClickアニメーションはtimelineに含まれない(
+        self, tmp_output_dir: Path
+    ):
+        """evt="onClick" のアニメーションは無人再生では発動しないため、
+        advTm の計算から除外されることを確認する。
+
+        onClick アニメーション(dur=10000ms)があっても advTm は音声長ベースになる。
+        """
+        from lxml import etree
+
+        _P = "http://schemas.openxmlformats.org/presentationml/2006/main"
+
+        spec = SlideSpec(
+            metadata=SlideMetadata(title="LT", subtitle="S", event="E"),
+            slides=[
+                Slide(layout="title_slide", title="表紙"),
+                Slide(layout="title_and_content", title="内容", body=["a"]),
+            ],
+        )
+        prs = build_presentation(spec)
+        pptx_path = tmp_output_dir / "onclick_base.pptx"
+        prs.save(str(pptx_path))
+
+        audio_dir = tmp_output_dir / "audio_onclick"
+        audio_dir.mkdir()
+        # 約6msのフェイクMP3
+        dummy_mp3 = b"\xff\xfb\x90\x00" + b"\x00" * 100
+        (audio_dir / "slide_001.mp3").write_bytes(dummy_mp3)
+        with_audio = tmp_output_dir / "onclick_audio.pptx"
+        embed_audio_to_pptx(pptx_path, audio_dir, with_audio)
+
+        # evt="onClick" + dur=10000ms のアニメーション（クリックしないと発動しない）
+        prs2 = Presentation(str(with_audio))
+        slide = prs2.slides[1]
+        timing_xml = f"""<p:timing xmlns:p="{_P}">
+  <p:tnLst>
+    <p:par>
+      <p:cTn id="1" dur="indefinite" restart="never" nodeType="tmRoot">
+        <p:childTnLst>
+          <p:seq concurrent="1" nextAc="seek">
+            <p:cTn id="2" dur="indefinite" nodeType="mainSeq">
+              <p:childTnLst>
+                <p:par>
+                  <p:cTn id="3" fill="hold">
+                    <p:stCondLst>
+                      <p:cond delay="0" evt="onClick"><p:tn val="2"/></p:cond>
+                    </p:stCondLst>
+                    <p:childTnLst>
+                      <p:par>
+                        <p:cTn id="4" dur="10000" fill="hold">
+                          <p:childTnLst>
+                            <p:anim calcmode="lin" valueType="num">
+                              <p:cBhvr>
+                                <p:cTn id="5" dur="10000" fill="hold"/>
+                                <p:tgtEl><p:spTgt spid="2"/></p:tgtEl>
+                                <p:attrNameLst><p:attrName>style.opacity</p:attrName></p:attrNameLst>
+                              </p:cBhvr>
+                            </p:anim>
+                          </p:childTnLst>
+                        </p:cTn>
+                      </p:par>
+                    </p:childTnLst>
+                  </p:cTn>
+                </p:par>
+              </p:childTnLst>
+            </p:cTn>
+          </p:seq>
+        </p:childTnLst>
+      </p:cTn>
+    </p:par>
+  </p:tnLst>
+</p:timing>"""
+        slide.element.append(etree.fromstring(timing_xml))
+        with_existing = tmp_output_dir / "onclick_existing.pptx"
+        prs2.save(str(with_existing))
+
+        out = tmp_output_dir / "onclick_out.pptx"
+        configure_slideshow(with_existing, out)
+
+        prs3 = Presentation(str(out))
+        slide_out = prs3.slides[1]
+        trans = slide_out.element.find("p:transition", _ns)
+
+        adv_tm = int(trans.get("advTm"))
+
+        # onClick アニメーション(10000ms)は無視されるため、advTm << 10000ms
+        assert adv_tm < 10000, (
+            f"advTm({adv_tm}ms) は onClick アニメーション(10000ms)の影響を受けてはいけない"
+        )

--- a/tests/test_slideshow.py
+++ b/tests/test_slideshow.py
@@ -964,3 +964,91 @@ class TestLibreOffice互換mainSeqDur:
         assert main_seq.get("dur") != "indefinite", (
             "mainSeq.dur は 'indefinite' のまま残ってはいけない"
         )
+
+    def test_遅延アニメーションを持つスライドでmainSeq_durが遅延を考慮する(
+        self, tmp_output_dir: Path
+    ):
+        """delay="5000" + dur="1000" の非音声アニメーションがある場合、
+        mainSeq.dur >= 6000ms になることを確認する（開始遅延を考慮した終了時刻）。
+        """
+        from lxml import etree
+
+        _P = "http://schemas.openxmlformats.org/presentationml/2006/main"
+
+        spec = SlideSpec(
+            metadata=SlideMetadata(title="LT", subtitle="S", event="E"),
+            slides=[
+                Slide(layout="title_slide", title="表紙"),
+                Slide(layout="title_and_content", title="内容", body=["a"]),
+            ],
+        )
+        prs = build_presentation(spec)
+        pptx_path = tmp_output_dir / "delay_anim_base.pptx"
+        prs.save(str(pptx_path))
+
+        audio_dir = tmp_output_dir / "audio_delay_anim"
+        audio_dir.mkdir()
+        # 約6msのフェイクMP3 (音声長 << 6000ms)
+        dummy_mp3 = b"\xff\xfb\x90\x00" + b"\x00" * 100
+        (audio_dir / "slide_001.mp3").write_bytes(dummy_mp3)
+        with_audio = tmp_output_dir / "delay_anim_audio.pptx"
+        embed_audio_to_pptx(pptx_path, audio_dir, with_audio)
+
+        # スライド1に delay="5000" + dur="1000" の非音声アニメーションを注入
+        prs2 = Presentation(str(with_audio))
+        slide = prs2.slides[1]
+        timing_xml = f"""<p:timing xmlns:p="{_P}">
+  <p:tnLst>
+    <p:par>
+      <p:cTn id="1" dur="indefinite" restart="never" nodeType="tmRoot">
+        <p:childTnLst>
+          <p:seq concurrent="1" nextAc="seek">
+            <p:cTn id="2" dur="indefinite" nodeType="mainSeq">
+              <p:childTnLst>
+                <p:par>
+                  <p:cTn id="3" fill="hold">
+                    <p:stCondLst><p:cond delay="5000"/></p:stCondLst>
+                    <p:childTnLst>
+                      <p:par>
+                        <p:cTn id="4" dur="1000" fill="hold">
+                          <p:stCondLst><p:cond delay="0"/></p:stCondLst>
+                          <p:childTnLst>
+                            <p:anim calcmode="lin" valueType="num">
+                              <p:cBhvr>
+                                <p:cTn id="5" dur="1000" fill="hold"/>
+                                <p:tgtEl><p:spTgt spid="2"/></p:tgtEl>
+                                <p:attrNameLst><p:attrName>style.opacity</p:attrName></p:attrNameLst>
+                              </p:cBhvr>
+                            </p:anim>
+                          </p:childTnLst>
+                        </p:cTn>
+                      </p:par>
+                    </p:childTnLst>
+                  </p:cTn>
+                </p:par>
+              </p:childTnLst>
+            </p:cTn>
+          </p:seq>
+        </p:childTnLst>
+      </p:cTn>
+    </p:par>
+  </p:tnLst>
+</p:timing>"""
+        slide.element.append(etree.fromstring(timing_xml))
+        with_existing = tmp_output_dir / "delay_anim_existing.pptx"
+        prs2.save(str(with_existing))
+
+        out = tmp_output_dir / "delay_anim_out.pptx"
+        configure_slideshow(with_existing, out)
+
+        prs3 = Presentation(str(out))
+        slide_out = prs3.slides[1]
+        main_seq = slide_out.element.find(".//p:cTn[@nodeType='mainSeq']", _ns)
+        assert main_seq is not None
+
+        dur = int(main_seq.get("dur"))
+        # delay=5000 + dur=1000 = 6000ms が必要
+        assert dur >= 6000, (
+            f"mainSeq.dur({dur}ms) は遅延(5000ms)+アニメーション(1000ms)=6000ms以上であるべき"
+        )
+        assert main_seq.get("dur") != "indefinite"

--- a/tests/test_slideshow.py
+++ b/tests/test_slideshow.py
@@ -1052,3 +1052,188 @@ class TestLibreOffice互換mainSeqDur:
             f"mainSeq.dur({dur}ms) は遅延(5000ms)+アニメーション(1000ms)=6000ms以上であるべき"
         )
         assert main_seq.get("dur") != "indefinite"
+
+    def test_ネスト遅延のアニメーションでmainSeq_durが累積遅延を考慮する(
+        self, tmp_output_dir: Path
+    ):
+        """外側delay=5000 + 内側delay=2000 + dur=1000 の場合、
+        mainSeq.dur >= 8000ms になることを確認する（ネスト遅延の累積）。
+        """
+        from lxml import etree
+
+        _P = "http://schemas.openxmlformats.org/presentationml/2006/main"
+
+        spec = SlideSpec(
+            metadata=SlideMetadata(title="LT", subtitle="S", event="E"),
+            slides=[
+                Slide(layout="title_slide", title="表紙"),
+                Slide(layout="title_and_content", title="内容", body=["a"]),
+            ],
+        )
+        prs = build_presentation(spec)
+        pptx_path = tmp_output_dir / "nested_delay_base.pptx"
+        prs.save(str(pptx_path))
+
+        audio_dir = tmp_output_dir / "audio_nested_delay"
+        audio_dir.mkdir()
+        dummy_mp3 = b"\xff\xfb\x90\x00" + b"\x00" * 100
+        (audio_dir / "slide_001.mp3").write_bytes(dummy_mp3)
+        with_audio = tmp_output_dir / "nested_delay_audio.pptx"
+        embed_audio_to_pptx(pptx_path, audio_dir, with_audio)
+
+        prs2 = Presentation(str(with_audio))
+        slide = prs2.slides[1]
+        # 外側 delay=5000, 内側 delay=2000, dur=1000 → 終了時刻 = 5000 + 2000 + 1000 = 8000ms
+        timing_xml = f"""<p:timing xmlns:p="{_P}">
+  <p:tnLst>
+    <p:par>
+      <p:cTn id="1" dur="indefinite" restart="never" nodeType="tmRoot">
+        <p:childTnLst>
+          <p:seq concurrent="1" nextAc="seek">
+            <p:cTn id="2" dur="indefinite" nodeType="mainSeq">
+              <p:childTnLst>
+                <p:par>
+                  <p:cTn id="3" fill="hold">
+                    <p:stCondLst><p:cond delay="5000"/></p:stCondLst>
+                    <p:childTnLst>
+                      <p:par>
+                        <p:cTn id="4" dur="1000" fill="hold">
+                          <p:stCondLst><p:cond delay="2000"/></p:stCondLst>
+                          <p:childTnLst>
+                            <p:anim calcmode="lin" valueType="num">
+                              <p:cBhvr>
+                                <p:cTn id="5" dur="1000" fill="hold"/>
+                                <p:tgtEl><p:spTgt spid="2"/></p:tgtEl>
+                                <p:attrNameLst><p:attrName>style.opacity</p:attrName></p:attrNameLst>
+                              </p:cBhvr>
+                            </p:anim>
+                          </p:childTnLst>
+                        </p:cTn>
+                      </p:par>
+                    </p:childTnLst>
+                  </p:cTn>
+                </p:par>
+              </p:childTnLst>
+            </p:cTn>
+          </p:seq>
+        </p:childTnLst>
+      </p:cTn>
+    </p:par>
+  </p:tnLst>
+</p:timing>"""
+        slide.element.append(etree.fromstring(timing_xml))
+        with_existing = tmp_output_dir / "nested_delay_existing.pptx"
+        prs2.save(str(with_existing))
+
+        out = tmp_output_dir / "nested_delay_out.pptx"
+        configure_slideshow(with_existing, out)
+
+        prs3 = Presentation(str(out))
+        slide_out = prs3.slides[1]
+        trans = slide_out.element.find("p:transition", _ns)
+        main_seq = slide_out.element.find(".//p:cTn[@nodeType='mainSeq']", _ns)
+
+        assert main_seq is not None
+        dur = int(main_seq.get("dur"))
+        adv_tm = int(trans.get("advTm"))
+
+        assert dur >= 8000, (
+            f"mainSeq.dur({dur}ms) は外側delay(5000)+内側delay(2000)+dur(1000)=8000ms以上であるべき"
+        )
+        assert adv_tm >= 8000, (
+            f"advTm({adv_tm}ms) は既存アニメーション終了時刻(8000ms)以上であるべき"
+        )
+
+    def test_既存アニメーションが長い場合advTmがアニメーション長に同期される(
+        self, tmp_output_dir: Path
+    ):
+        """音声長 < 既存アニメーション終了時刻のとき、
+        advTm が既存アニメーション長 + buffer 以上になることを確認する。
+
+        PowerPoint はadvTmで進むため、advTmが短いと既存アニメーション完了前に
+        スライドが進んでしまう。advTmは max(音声長, アニメーション終了) + buffer 以上にする。
+        """
+        from lxml import etree
+
+        _P = "http://schemas.openxmlformats.org/presentationml/2006/main"
+
+        spec = SlideSpec(
+            metadata=SlideMetadata(title="LT", subtitle="S", event="E"),
+            slides=[
+                Slide(layout="title_slide", title="表紙"),
+                Slide(layout="title_and_content", title="内容", body=["a"]),
+            ],
+        )
+        prs = build_presentation(spec)
+        pptx_path = tmp_output_dir / "adv_sync_base.pptx"
+        prs.save(str(pptx_path))
+
+        audio_dir = tmp_output_dir / "audio_adv_sync"
+        audio_dir.mkdir()
+        # 約6msのフェイクMP3 (音声長 << 5000ms アニメーション)
+        dummy_mp3 = b"\xff\xfb\x90\x00" + b"\x00" * 100
+        (audio_dir / "slide_001.mp3").write_bytes(dummy_mp3)
+        with_audio = tmp_output_dir / "adv_sync_audio.pptx"
+        embed_audio_to_pptx(pptx_path, audio_dir, with_audio)
+
+        prs2 = Presentation(str(with_audio))
+        slide = prs2.slides[1]
+        timing_xml = f"""<p:timing xmlns:p="{_P}">
+  <p:tnLst>
+    <p:par>
+      <p:cTn id="1" dur="indefinite" restart="never" nodeType="tmRoot">
+        <p:childTnLst>
+          <p:seq concurrent="1" nextAc="seek">
+            <p:cTn id="2" dur="indefinite" nodeType="mainSeq">
+              <p:childTnLst>
+                <p:par>
+                  <p:cTn id="3" fill="hold">
+                    <p:stCondLst><p:cond delay="0"/></p:stCondLst>
+                    <p:childTnLst>
+                      <p:par>
+                        <p:cTn id="4" dur="5000" fill="hold">
+                          <p:childTnLst>
+                            <p:anim calcmode="lin" valueType="num">
+                              <p:cBhvr>
+                                <p:cTn id="5" dur="5000" fill="hold"/>
+                                <p:tgtEl><p:spTgt spid="2"/></p:tgtEl>
+                                <p:attrNameLst><p:attrName>style.opacity</p:attrName></p:attrNameLst>
+                              </p:cBhvr>
+                            </p:anim>
+                          </p:childTnLst>
+                        </p:cTn>
+                      </p:par>
+                    </p:childTnLst>
+                  </p:cTn>
+                </p:par>
+              </p:childTnLst>
+            </p:cTn>
+          </p:seq>
+        </p:childTnLst>
+      </p:cTn>
+    </p:par>
+  </p:tnLst>
+</p:timing>"""
+        slide.element.append(etree.fromstring(timing_xml))
+        with_existing = tmp_output_dir / "adv_sync_existing.pptx"
+        prs2.save(str(with_existing))
+
+        out = tmp_output_dir / "adv_sync_out.pptx"
+        configure_slideshow(with_existing, out)
+
+        prs3 = Presentation(str(out))
+        slide_out = prs3.slides[1]
+        trans = slide_out.element.find("p:transition", _ns)
+        main_seq = slide_out.element.find(".//p:cTn[@nodeType='mainSeq']", _ns)
+
+        assert main_seq is not None
+        adv_tm = int(trans.get("advTm"))
+        dur = int(main_seq.get("dur"))
+
+        # advTm は既存アニメーション(5000ms) + buffer(1000ms) = 6000ms 以上
+        assert adv_tm >= 5000 + 1000, (
+            f"advTm({adv_tm}ms) は 既存アニメーション(5000ms) + buffer(1000ms) 以上であるべき"
+        )
+        assert dur >= 5000, (
+            f"mainSeq.dur({dur}ms) は既存アニメーション(5000ms)以上であるべき"
+        )

--- a/tests/test_slideshow.py
+++ b/tests/test_slideshow.py
@@ -1237,3 +1237,119 @@ class TestLibreOffice互換mainSeqDur:
         assert dur >= 5000, (
             f"mainSeq.dur({dur}ms) は既存アニメーション(5000ms)以上であるべき"
         )
+
+    def test_既知制限_onEndイベント連鎖アニメーションの合計は計算されない(
+        self, tmp_output_dir: Path
+    ):
+        """[既知の制限] "After Previous" (evt="onEnd") による連鎖アニメーションの
+        合計時間は計算されない。各エフェクトの最大時間のみが考慮される。
+
+        daida-ai は "After Previous" アニメーションを生成しないため実用上問題なし。
+        外部 PPTX を configure_slideshow に渡す場合は、連鎖アニメーションの
+        合計が正確に計算されないことに注意。
+        """
+        from lxml import etree
+
+        _P = "http://schemas.openxmlformats.org/presentationml/2006/main"
+
+        spec = SlideSpec(
+            metadata=SlideMetadata(title="LT", subtitle="S", event="E"),
+            slides=[
+                Slide(layout="title_slide", title="表紙"),
+                Slide(layout="title_and_content", title="内容", body=["a"]),
+            ],
+        )
+        prs = build_presentation(spec)
+        pptx_path = tmp_output_dir / "event_chain_base.pptx"
+        prs.save(str(pptx_path))
+
+        audio_dir = tmp_output_dir / "audio_event_chain"
+        audio_dir.mkdir()
+        dummy_mp3 = b"\xff\xfb\x90\x00" + b"\x00" * 100
+        (audio_dir / "slide_001.mp3").write_bytes(dummy_mp3)
+        with_audio = tmp_output_dir / "event_chain_audio.pptx"
+        embed_audio_to_pptx(pptx_path, audio_dir, with_audio)
+
+        prs2 = Presentation(str(with_audio))
+        slide = prs2.slides[1]
+        # "After Previous" チェーン: anim1(dur=1000) → anim2(onEnd→anim1, dur=2000)
+        # 真の合計時間 = 1000 + 2000 = 3000ms だが、現実装は max(1000, 2000) = 2000ms のみ
+        timing_xml = f"""<p:timing xmlns:p="{_P}">
+  <p:tnLst>
+    <p:par>
+      <p:cTn id="1" dur="indefinite" restart="never" nodeType="tmRoot">
+        <p:childTnLst>
+          <p:seq concurrent="1" nextAc="seek">
+            <p:cTn id="2" dur="indefinite" nodeType="mainSeq">
+              <p:childTnLst>
+                <p:par>
+                  <p:cTn id="3" fill="hold">
+                    <p:stCondLst><p:cond delay="0"/></p:stCondLst>
+                    <p:childTnLst>
+                      <p:par>
+                        <p:cTn id="4" dur="1000" fill="hold">
+                          <p:childTnLst>
+                            <p:anim calcmode="lin" valueType="num">
+                              <p:cBhvr>
+                                <p:cTn id="5" dur="1000" fill="hold"/>
+                                <p:tgtEl><p:spTgt spid="2"/></p:tgtEl>
+                                <p:attrNameLst><p:attrName>style.opacity</p:attrName></p:attrNameLst>
+                              </p:cBhvr>
+                            </p:anim>
+                          </p:childTnLst>
+                        </p:cTn>
+                      </p:par>
+                    </p:childTnLst>
+                  </p:cTn>
+                </p:par>
+                <p:par>
+                  <p:cTn id="6" fill="hold">
+                    <p:stCondLst>
+                      <p:cond delay="0" evt="onEnd"><p:tn val="4"/></p:cond>
+                    </p:stCondLst>
+                    <p:childTnLst>
+                      <p:par>
+                        <p:cTn id="7" dur="2000" fill="hold">
+                          <p:childTnLst>
+                            <p:anim calcmode="lin" valueType="num">
+                              <p:cBhvr>
+                                <p:cTn id="8" dur="2000" fill="hold"/>
+                                <p:tgtEl><p:spTgt spid="2"/></p:tgtEl>
+                                <p:attrNameLst><p:attrName>ppt.x</p:attrName></p:attrNameLst>
+                              </p:cBhvr>
+                            </p:anim>
+                          </p:childTnLst>
+                        </p:cTn>
+                      </p:par>
+                    </p:childTnLst>
+                  </p:cTn>
+                </p:par>
+              </p:childTnLst>
+            </p:cTn>
+          </p:seq>
+        </p:childTnLst>
+      </p:cTn>
+    </p:par>
+  </p:tnLst>
+</p:timing>"""
+        slide.element.append(etree.fromstring(timing_xml))
+        with_existing = tmp_output_dir / "event_chain_existing.pptx"
+        prs2.save(str(with_existing))
+
+        out = tmp_output_dir / "event_chain_out.pptx"
+        configure_slideshow(with_existing, out)
+
+        prs3 = Presentation(str(out))
+        slide_out = prs3.slides[1]
+        main_seq = slide_out.element.find(".//p:cTn[@nodeType='mainSeq']", _ns)
+
+        assert main_seq is not None
+        dur = int(main_seq.get("dur"))
+
+        # [既知制限] onEnd チェーンの合計(3000ms)は計算されず、最大値(2000ms)が使われる
+        # daida-ai は onEnd チェーンを生成しないため実用上は問題なし
+        assert dur >= 2000, (
+            f"mainSeq.dur({dur}ms) は少なくとも最大エフェクト長(2000ms)以上であるべき"
+        )
+        # 合計3000msが計算されないことは既知の制限 — これが変わった場合テストを更新する
+        # (3000ms以上であれば改善されたことを示す)

--- a/tests/test_slideshow.py
+++ b/tests/test_slideshow.py
@@ -744,3 +744,68 @@ class TestLibreOffice互換mainSeqDur:
         assert len(audio_nodes) == 1, (
             f"2回適用しても audio ノードは1つだけであるべき: {len(audio_nodes)} 個"
         )
+
+    def test_音声長ゼロのとき_fallback_durationが使われmainSeq_durが正になる(
+        self, tmp_output_dir: Path
+    ):
+        """_get_audio_duration_ms が 0 を返すとき（WAV/外部音声）、
+        unmeasurable_duration_ms がフォールバックとして使われ、
+        mainSeq.dur が "indefinite" のまま残らないことを確認する。
+        """
+        from unittest.mock import patch
+
+        spec = SlideSpec(
+            metadata=SlideMetadata(title="LT", subtitle="S", event="E"),
+            slides=[Slide(layout="title_slide", title="表紙")],
+        )
+        prs = build_presentation(spec)
+        pptx_path = tmp_output_dir / "test_wav.pptx"
+        prs.save(str(pptx_path))
+
+        audio_dir = tmp_output_dir / "audio_wav"
+        audio_dir.mkdir()
+        # WAV ヘッダ (non-MP3) → _estimate_mp3_duration_ms が 0 を返す
+        wav_header = b"RIFF" + b"\x00" * 40
+        (audio_dir / "slide_000.mp3").write_bytes(wav_header)
+
+        out_with_audio = tmp_output_dir / "wav_with_audio.pptx"
+        embed_audio_to_pptx(pptx_path, audio_dir, out_with_audio)
+
+        out_final = tmp_output_dir / "wav_final.pptx"
+        fallback_ms = 20000
+        configure_slideshow(
+            out_with_audio, out_final, unmeasurable_duration_ms=fallback_ms
+        )
+
+        prs2 = Presentation(str(out_final))
+        slide = prs2.slides[0]
+        main_seq_ctn = slide.element.find(".//p:cTn[@nodeType='mainSeq']", _ns)
+
+        if main_seq_ctn is not None:
+            dur = main_seq_ctn.get("dur")
+            assert dur != "indefinite", (
+                "WAV/計測不能音声でも mainSeq.dur は 'indefinite' であってはならない"
+            )
+            assert int(dur) >= 1, f"dur は 1ms 以上であるべき: {dur}"
+
+    def test_既存の非音声アニメーションがmainSeq_dur設定後も消えない(
+        self, pptx_with_audio: Path, tmp_output_dir: Path
+    ):
+        """configure_slideshow 後も既存の音声 audio ノードが保持されること。
+
+        Note: daida-ai が生成するスライドには他のアニメーションノードが存在しないため、
+        「音声アニメーションのみ」のケースで重複なく保持されることを検証する。
+        2回適用しても audio ノードが増殖しないことで、既存構造の破壊がないことを示す。
+        """
+        output1 = tmp_output_dir / "anim_pass1.pptx"
+        configure_slideshow(pptx_with_audio, output1)
+
+        output2 = tmp_output_dir / "anim_pass2.pptx"
+        configure_slideshow(output1, output2)
+
+        prs = Presentation(str(output2))
+        for i, slide in enumerate(prs.slides):
+            audio_nodes = slide.element.findall(".//p:audio", _ns)
+            assert len(audio_nodes) <= 1, (
+                f"スライド {i}: audio ノードが重複してはいけない: {len(audio_nodes)} 個"
+            )

--- a/tests/test_slideshow.py
+++ b/tests/test_slideshow.py
@@ -781,12 +781,14 @@ class TestLibreOffice互換mainSeqDur:
         slide = prs2.slides[0]
         main_seq_ctn = slide.element.find(".//p:cTn[@nodeType='mainSeq']", _ns)
 
-        if main_seq_ctn is not None:
-            dur = main_seq_ctn.get("dur")
-            assert dur != "indefinite", (
-                "WAV/計測不能音声でも mainSeq.dur は 'indefinite' であってはならない"
-            )
-            assert int(dur) >= 1, f"dur は 1ms 以上であるべき: {dur}"
+        assert main_seq_ctn is not None, (
+            "WAV/計測不能音声でも p:timing/mainSeq が生成されるべき"
+        )
+        dur = main_seq_ctn.get("dur")
+        assert dur != "indefinite", (
+            "WAV/計測不能音声でも mainSeq.dur は 'indefinite' であってはならない"
+        )
+        assert int(dur) >= 1, f"dur は 1ms 以上であるべき: {dur}"
 
     def test_既存の非音声アニメーションがmainSeq_dur設定後も消えない(
         self, pptx_with_audio: Path, tmp_output_dir: Path

--- a/tests/test_slideshow.py
+++ b/tests/test_slideshow.py
@@ -650,3 +650,61 @@ class Testノートベースタイミング:
             assert not has_notes_after, (
                 "ノートなしスライドに空のnotesが勝手に作られてはいけない"
             )
+
+
+class TestLibreOffice互換mainSeqDur:
+    """LibreOffice互換: mainSeq の dur が音声長に設定される"""
+
+    def test_音声ありスライドのmainSeq_durが音声長になる(
+        self, pptx_with_audio: Path, tmp_output_dir: Path
+    ):
+        """mainSeq p:cTn の dur が "indefinite" でなく音声長(ms)であること"""
+        output = tmp_output_dir / "show_lo.pptx"
+        configure_slideshow(pptx_with_audio, output)
+
+        prs = Presentation(str(output))
+        # スライド1 (音声あり: slide_001.mp3 → index 1)
+        slide = prs.slides[1]
+        main_seq_ctn = slide.element.find(
+            ".//p:cTn[@nodeType='mainSeq']", _ns
+        )
+        assert main_seq_ctn is not None, "mainSeq p:cTn が存在すること"
+        dur = main_seq_ctn.get("dur")
+        assert dur != "indefinite", (
+            f"LibreOffice互換のため dur は 'indefinite' であってはならない: {dur}"
+        )
+        assert dur is not None and int(dur) > 0, (
+            f"dur は正の整数(ms)であること: {dur}"
+        )
+
+    def test_音声なしスライドにはmainSeq_durが設定されない(
+        self, pptx_with_audio: Path, tmp_output_dir: Path
+    ):
+        """音声なしスライドには p:timing が追加されないこと"""
+        output = tmp_output_dir / "show_lo_no_audio.pptx"
+        configure_slideshow(pptx_with_audio, output)
+
+        prs = Presentation(str(output))
+        # スライド0 (音声なし: title_slide に mp3 なし)
+        slide = prs.slides[0]
+        timing = slide.element.find("p:timing", _ns)
+        assert timing is None, "音声なしスライドに p:timing は不要"
+
+    def test_mainSeq_durがadvTmと同等以下である(
+        self, pptx_with_audio: Path, tmp_output_dir: Path
+    ):
+        """mainSeq dur <= advTm であること（音声が終わった後にページ送り）"""
+        output = tmp_output_dir / "show_lo_dur.pptx"
+        configure_slideshow(pptx_with_audio, output, audio_buffer_ms=1000)
+
+        prs = Presentation(str(output))
+        # スライド1 (音声あり)
+        slide = prs.slides[1]
+        trans = slide.element.find("p:transition", _ns)
+        main_seq_ctn = slide.element.find(".//p:cTn[@nodeType='mainSeq']", _ns)
+
+        adv_tm = int(trans.get("advTm"))
+        dur = int(main_seq_ctn.get("dur"))
+        assert dur <= adv_tm, (
+            f"mainSeq dur({dur}ms) は advTm({adv_tm}ms) 以下であるべき"
+        )


### PR DESCRIPTION
## Summary

- LibreOffice Impress で音声は再生されるがページが自動送りされない問題を修正
- 原因: `mainSeq` の `dur="indefinite"` により `notifySlideAnimationsEnded()` が呼ばれず `advTm` タイマーが発火しない
- 修正: `mainSeq` の `dur` を音声の実際の長さ（ms）に設定し、音声終了時にアニメーション終了が確実に発火するようにした

## Root Cause (LibreOffice source code analysis)

LibreOffice の `slideshowimpl.cxx` より:
- `notifySlideAnimationsEnded()` が呼ばれて初めて `queryAutomaticSlideTransition()` が発動し `advTm` タイマーが起動する
- `dur="indefinite"` の mainSeq はアニメーションが永遠に終わらない → `notifySlideAnimationsEnded()` が呼ばれない → ページが進まない

## Changes

- `_build_timing_xml`: `main_seq_dur_ms` 引数を追加。0 の場合は `"indefinite"`、正の値の場合はその値を `dur` に設定
- `_merge_audio_into_timing`: 既存 timing に audio をマージする際も `mainSeq.dur` を更新
- `_add_auto_play_animation`: `main_seq_dur_ms` を受け取って下位関数に渡す
- `configure_slideshow`: `audio_duration` を `main_seq_dur_ms` として渡す

## Test plan

- [ ] `test_音声ありスライドのmainSeq_durが音声長になる` — mainSeq.dur が "indefinite" でなく正の整数であること
- [ ] `test_音声なしスライドにはmainSeq_durが設定されない` — 音声なしスライドに p:timing が追加されないこと
- [ ] `test_mainSeq_durがadvTmと同等以下である` — mainSeq.dur ≤ advTm であること
- [ ] 全266テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)