### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "daida-ai",
   "description": "LTプレゼン自動生成 — テーマからスライド・音声ナレーション付きPPTXまで一括対応",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": {
     "name": "hawkymisc"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "daida-ai"
-version = "0.1.0"
+version = "0.2.0"
 description = "LT presentation auto-generation Agent Skill"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary
- plugin.json / pyproject.toml のバージョンを 0.1.0 → 0.2.0 に更新

## Changes since 0.1.0
- PR #33: LibreOffice自動ページ送り対応（mainSeq.dur設定、12 rounds Codex review）
- PR #36: macOS PowerPoint互換（p:cmd方式 + 可視アイコン）
- PR #37: LibreOffice Impress非対応ドキュメント追加

## Test plan
- [x] plugin.json version updated
- [x] pyproject.toml version updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)