### PR TITLE
feat: A4 TTS障害時の部分成功フォールバック

### DIFF
--- a/daida_ai/lib/synthesize.py
+++ b/daida_ai/lib/synthesize.py
@@ -2,10 +2,12 @@
 
 スピーカーノートのリストからTTSエンジンで音声ファイルを生成する。
 空ノートはスキップし、slide_NNN.mp3 形式で出力する。
+個別スライドのTTS失敗はスキップし、成功分のみ返す（部分成功）。
 """
 
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
 
 from daida_ai.lib.tts_engine import TTSEngine, get_engine
@@ -48,7 +50,15 @@ async def synthesize_notes(
             results.append(None)
             continue
         output_path = output_dir / f"slide_{i:03d}.mp3"
-        await engine.synthesize(note, output_path, voice=voice)
-        results.append(output_path)
+        try:
+            await engine.synthesize(note, output_path, voice=voice)
+            results.append(output_path)
+        except Exception as e:
+            warnings.warn(
+                f"TTS failed for slide {i}: {e}",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            results.append(None)
 
     return results

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -138,13 +138,23 @@ EDGE_CASES = [
 | SVG変換 — 不正なSVG | `SVGConversionError`を送出 | `test_svg_to_png.py` |
 | パストラバーサル | `ValueError`を送出 | `test_slide_builder.py` |
 
+| TTS API障害（部分成功） | 失敗スライドをスキップし、成功分のみ返す。warningを発行 | `test_synthesize_audio.py` (TestA4_TTS障害時フォールバック) |
+| TTS API障害（全失敗） | 全スライドNoneを返し、クラッシュしない | `test_synthesize_audio.py` |
+
 ### 計画中（テスト未実装）
 
 | 障害箇所 | アサーション |
 |----------|-------------|
-| TTS API（VOICEVOX）障害 | 例外がハンドリングされ、音声なしPPTXが出力される（部分成功） |
-| LLM API障害 | 明確なエラーメッセージが返り、未処理例外が発生しない |
 | Skillワークフロー: Gemini障害→SVGフォールバック | SVGで代替画像を生成し、パイプライン完走する |
+
+> **TTS障害時の復旧フロー**: TTS失敗時は `synthesize_notes()` が失敗スライドをスキップし、成功分のみ返す（部分成功）。
+> `synthesize_audio.py` は失敗数をstderrに報告して正常終了する。
+> TTS復旧後にStep 4を再実行すれば全スライドの音声が生成される。
+
+> **LLM API障害について**: パイプライン全体がClaude Code上で実行され、
+> LLMとの対話はClaude Code自身が担当する（`daida_ai/lib/` も `scripts/` もLLM APIを直接呼ばない）。
+> LLM API障害時はClaude Code自体が動作不能になるため、ライブラリ側でのテストは不要・不可能。
+> LLMが生成する中間データの妥当性はA1（SlideSpec構造バリデーション）でガードされている。
 
 ## A5. タイミング推定式の精度検証
 

--- a/skills/daida-ai/SKILL.md
+++ b/skills/daida-ai/SKILL.md
@@ -458,6 +458,15 @@ VOICEVOX使用時（事前にVOICEVOX Engineの起動が必要）:
 bash ${CLAUDE_SKILL_DIR}/scripts/run.sh synthesize_audio.py output/presentation.pptx output/audio/ --engine voicevox
 ```
 
+### TTS障害時の対応
+
+TTS APIが一部または全スライドで失敗した場合、失敗したスライドはスキップされ、成功分のみ音声ファイルが生成される（部分成功）。
+
+- スクリプトは失敗数をstderrに報告し、正常終了する
+- 音声なしスライドはStep 6でデフォルト時間（3秒）で自動送りされる
+- TTS復旧後、Step 4を再実行すれば全スライドの音声が生成される
+- Step 2で生成したPPTXはそのまま利用可能（音声なしでも発表は可能）
+
 ---
 
 ## Step 5: 音声埋め込み

--- a/skills/daida-ai/scripts/synthesize_audio.py
+++ b/skills/daida-ai/scripts/synthesize_audio.py
@@ -39,7 +39,14 @@ def main():
         )
     )
     generated = sum(1 for r in results if r is not None)
+    failed = non_empty - generated
     print(f"Generated {generated} audio files.")
+    if failed > 0:
+        print(
+            f"Warning: {failed} slide(s) failed TTS synthesis. "
+            f"Re-run Step 4 after resolving the TTS issue.",
+            file=sys.stderr,
+        )
     print("Done.")
 
 

--- a/tests/test_synthesize_audio.py
+++ b/tests/test_synthesize_audio.py
@@ -194,3 +194,74 @@ class Testエラーハンドリング:
             await synthesize_notes(
                 ["テスト"], tmp_output_dir / "audio"
             )
+
+
+class TestA4_TTS障害時フォールバック:
+    """A4: TTS APIが一部スライドで失敗しても、成功分は保持される"""
+
+    @pytest.fixture
+    def failing_engine(self):
+        """2番目のスライドで例外を投げるモックエンジン"""
+        engine = AsyncMock()
+        call_count = 0
+
+        async def partial_fail(text, output_path, voice=None):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                raise ConnectionError("VOICEVOX connection refused")
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(b"\xff\xfb\x90\x00" + b"\x00" * 50)
+            return output_path
+
+        engine.synthesize.side_effect = partial_fail
+        return engine
+
+    @pytest.mark.asyncio
+    async def test_一部スライドが失敗しても残りは生成される(
+        self, tmp_output_dir: Path, failing_engine
+    ):
+        notes = ["スライド1", "スライド2", "スライド3"]
+        audio_dir = tmp_output_dir / "audio"
+
+        results = await synthesize_notes(
+            notes, audio_dir, engine=failing_engine
+        )
+
+        assert results[0] is not None  # 成功
+        assert results[1] is None      # 失敗→スキップ
+        assert results[2] is not None  # 成功
+
+    @pytest.mark.asyncio
+    async def test_全スライド失敗でもクラッシュしない(
+        self, tmp_output_dir: Path
+    ):
+        engine = AsyncMock()
+        engine.synthesize.side_effect = ConnectionError("VOICEVOX down")
+
+        notes = ["スライド1", "スライド2"]
+        audio_dir = tmp_output_dir / "audio"
+
+        results = await synthesize_notes(
+            notes, audio_dir, engine=engine
+        )
+
+        assert all(r is None for r in results)
+
+    @pytest.mark.asyncio
+    async def test_失敗したスライドの情報がwarningsに含まれる(
+        self, tmp_output_dir: Path, failing_engine
+    ):
+        import warnings
+
+        notes = ["スライド1", "スライド2", "スライド3"]
+        audio_dir = tmp_output_dir / "audio"
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            await synthesize_notes(
+                notes, audio_dir, engine=failing_engine
+            )
+
+            tts_warnings = [x for x in w if "TTS" in str(x.message) or "slide" in str(x.message).lower()]
+            assert len(tts_warnings) >= 1


### PR DESCRIPTION
## Summary
- `synthesize_notes()` に個別スライドのTTS例外ハンドリングを追加（部分成功）
- 失敗スライドをスキップし、成功分のみ返す。`warnings.warn()` で失敗情報を通知
- `synthesize_audio.py` は失敗数をstderrに報告して正常終了
- SKILL.md Step 4にTTS障害時の対応セクションを追記
- evaluation.md A4を更新（TTS→実装済み、LLM API→テスト不要として整理）

## Test plan
- [x] TTS部分成功テスト（3スライド中1つ失敗→残り2つ成功）
- [x] TTS全失敗テスト（全スライドNone、クラッシュなし）
- [x] warning発行テスト
- [x] 全テスト 333 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)