### PR TITLE
test: A5 MP3デュレーション計測ユニットテスト

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -170,15 +170,18 @@ EDGE_CASES = [
 | 長いノートの推定時間 | 長いノートほど長いadvTmになる | `test_slideshow.py` (`test_長いノートは長いadvTmになる`) |
 | 最低値制約 | 短いノートでも最低3秒（`_MIN_NOTE_DURATION_MS`） | `test_slideshow.py` (`test_ノートベースタイミングの最低値は3秒`) |
 
-> **音声デュレーション計測について**: `_estimate_mp3_duration_ms()` はMP3フレームヘッダからビットレートを判定して
-> デュレーションを計算するが、既存テスト（`test_音声ありスライドのmainSeq_durが音声長になる`）は
-> dur属性が非空かつ"indefinite"でないことのみ検証しており、実際のms値の正確さは未検証。
+| MP3デュレーション計測（MPEG1 128kbps） | 既知データサイズから期待ms値と一致 | `test_slideshow.py` (TestA5_estimate_mp3_duration_ms) |
+| MP3デュレーション計測（MPEG2 64kbps） | 既知データサイズから期待ms値と一致 | `test_slideshow.py` |
+| ID3タグ付きMP3 | ID3スキップ後のデータ量で正しく計算 | `test_slideshow.py` |
+| フレームヘッダなし | 0を返す | `test_slideshow.py` |
+| 空データ / 10バイト未満 | 0を返す | `test_slideshow.py` |
+
+テスト用MP3データは `conftest.py` の `build_mp3_frame()` / `build_id3_header()` で構築。fixture名: `mp3_mpeg1_128kbps`, `mp3_mpeg2_64kbps`, `mp3_with_id3_tag`, `mp3_no_frame_header`。
 
 ### 計画中（テスト未実装）
 
 | テスト項目 | アサーション |
 |-----------|-------------|
-| `_estimate_mp3_duration_ms`ユニットテスト | 既知のMP3ペイロードに対して計算値が実際のデュレーションと一致 |
 | 実TTS音声長との比較 | 推定時間と実VOICEVOX音声長の誤差率平均 < 20% |
 
 > **注意**: 実TTS音声長との比較はVOICEVOXがローカル起動済みの環境でのみ実行可能。

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,63 @@
-"""共通fixtures: サンプルアウトライン、一時ディレクトリ、モックPPTX"""
+"""共通fixtures: サンプルアウトライン、一時ディレクトリ、モックPPTX、MP3テストデータ"""
 
 import pytest
 from pathlib import Path
 import tempfile
 from PIL import Image
+
+
+# ---------------------------------------------------------------------------
+# MP3テストデータ構築ヘルパー
+# ---------------------------------------------------------------------------
+
+def build_mp3_frame(
+    *,
+    mpeg1: bool = True,
+    bitrate_idx: int = 0b1001,
+    audio_size: int = 16000,
+) -> bytes:
+    """テスト用MP3フレームヘッダ + ダミー音声データを構築する。
+
+    Args:
+        mpeg1: True=MPEG1(0xFB), False=MPEG2(0xF3)
+        bitrate_idx: ビットレートインデックス（4bit）。MPEG1: 0b1001=128kbps, MPEG2: 0b1000=64kbps
+        audio_size: フレームヘッダ以降の音声データサイズ（バイト）
+
+    Returns:
+        MP3フレームヘッダ + ゼロ埋めデータ
+
+    期待デュレーション計算:
+        duration_ms = (audio_size + 4) * 8 / (bitrate_kbps * 1000) * 1000
+        ※ +4 はフレームヘッダ4バイト分（_estimate_mp3_duration_msは offset以降の全バイトを使う）
+    """
+    # byte0: 0xFF（sync）
+    # byte1: MPEG1 Layer3 = 0xFB (11111011), MPEG2 Layer3 = 0xF3 (11110011)
+    byte1 = 0xFB if mpeg1 else 0xF3
+    # byte2: ビットレートインデックス(上位4bit) + サンプリングレート(00) + パディング(0) + チャネル(0)
+    byte2 = (bitrate_idx << 4) & 0xF0
+    # byte3: 0x00
+    header = bytes([0xFF, byte1, byte2, 0x00])
+    return header + b"\x00" * audio_size
+
+
+def build_id3_header(tag_size: int = 0) -> bytes:
+    """ID3v2ヘッダを構築する。
+
+    Args:
+        tag_size: ID3タグのデータサイズ（ヘッダ10バイトを含まない）
+
+    Returns:
+        10バイトのID3ヘッダ + ゼロ埋めタグデータ
+    """
+    # ID3v2.3, フラグ=0, サイズはsyncsafe integer
+    s = tag_size
+    size_bytes = bytes([
+        (s >> 21) & 0x7F,
+        (s >> 14) & 0x7F,
+        (s >> 7) & 0x7F,
+        s & 0x7F,
+    ])
+    return b"ID3" + bytes([0x03, 0x00, 0x00]) + size_bytes + b"\x00" * tag_size
 
 
 @pytest.fixture
@@ -101,3 +155,55 @@ def sample_svg(tmp_output_dir) -> Path:
         "</svg>"
     )
     return path
+
+
+# ---------------------------------------------------------------------------
+# MP3 fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mp3_mpeg1_128kbps() -> tuple[bytes, int]:
+    """MPEG1 128kbps, 16000bytes音声データ。
+
+    Returns:
+        (mp3_data, expected_duration_ms)
+        duration = (16000 + 4) * 8 / (128 * 1000) * 1000 = 1000.25 → 1000ms
+    """
+    data = build_mp3_frame(mpeg1=True, bitrate_idx=0b1001, audio_size=16000)
+    expected_ms = int((len(data)) * 8 / (128 * 1000) * 1000)
+    return data, expected_ms
+
+
+@pytest.fixture
+def mp3_mpeg2_64kbps() -> tuple[bytes, int]:
+    """MPEG2 64kbps, 8000bytes音声データ。
+
+    Returns:
+        (mp3_data, expected_duration_ms)
+        duration = (8000 + 4) * 8 / (64 * 1000) * 1000 = 1000.5 → 1000ms
+    """
+    data = build_mp3_frame(mpeg1=False, bitrate_idx=0b1000, audio_size=8000)
+    expected_ms = int((len(data)) * 8 / (64 * 1000) * 1000)
+    return data, expected_ms
+
+
+@pytest.fixture
+def mp3_with_id3_tag() -> tuple[bytes, int]:
+    """ID3タグ付きMPEG1 128kbps。
+
+    Returns:
+        (mp3_data, expected_duration_ms)
+        ID3タグ(10+100bytes)の後にMP3フレーム。デュレーションはフレーム部分のみで計算。
+    """
+    id3 = build_id3_header(tag_size=100)
+    frame = build_mp3_frame(mpeg1=True, bitrate_idx=0b1001, audio_size=16000)
+    data = id3 + frame
+    audio_bytes = len(frame)  # ID3スキップ後のバイト数
+    expected_ms = int(audio_bytes * 8 / (128 * 1000) * 1000)
+    return data, expected_ms
+
+
+@pytest.fixture
+def mp3_no_frame_header() -> bytes:
+    """MP3フレームヘッダが存在しないデータ。0を返すべき。"""
+    return b"\x00" * 200

--- a/tests/test_slideshow.py
+++ b/tests/test_slideshow.py
@@ -8,7 +8,7 @@ from pptx import Presentation
 from daida_ai.lib.slide_spec import SlideSpec, SlideMetadata, Slide
 from daida_ai.lib.slide_builder import build_presentation
 from daida_ai.lib.audio_embed import embed_audio_to_pptx
-from daida_ai.lib.slideshow import configure_slideshow
+from daida_ai.lib.slideshow import configure_slideshow, _estimate_mp3_duration_ms
 
 # OOXML名前空間
 _ns = {
@@ -2032,3 +2032,44 @@ class TestLibreOffice互換mainSeqDur:
         trans = slide_out.element.find("p:transition", _ns)
         adv_tm = int(trans.get("advTm"))
         assert adv_tm > 0, f"循環参照があっても advTm は正の値であるべき: {adv_tm}"
+
+
+class TestA5_estimate_mp3_duration_ms:
+    """A5: _estimate_mp3_duration_ms のユニットテスト
+
+    conftest.py の build_mp3_frame / build_id3_header を使って
+    既知のビットレート・データサイズから期待ms値を検証する。
+    """
+
+    def test_MPEG1_128kbps(self, mp3_mpeg1_128kbps):
+        data, expected_ms = mp3_mpeg1_128kbps
+        result = _estimate_mp3_duration_ms(data)
+        assert result == expected_ms
+
+    def test_MPEG2_64kbps(self, mp3_mpeg2_64kbps):
+        data, expected_ms = mp3_mpeg2_64kbps
+        result = _estimate_mp3_duration_ms(data)
+        assert result == expected_ms
+
+    def test_ID3タグ付きMP3(self, mp3_with_id3_tag):
+        data, expected_ms = mp3_with_id3_tag
+        result = _estimate_mp3_duration_ms(data)
+        assert result == expected_ms
+
+    def test_フレームヘッダなしは0を返す(self, mp3_no_frame_header):
+        result = _estimate_mp3_duration_ms(mp3_no_frame_header)
+        assert result == 0
+
+    def test_空データは0を返す(self):
+        result = _estimate_mp3_duration_ms(b"")
+        assert result == 0
+
+    def test_10バイト未満は0を返す(self):
+        result = _estimate_mp3_duration_ms(b"\x00" * 5)
+        assert result == 0
+
+    def test_戻り値は常に非負整数(self, mp3_mpeg1_128kbps):
+        data, _ = mp3_mpeg1_128kbps
+        result = _estimate_mp3_duration_ms(data)
+        assert isinstance(result, int)
+        assert result >= 0


### PR DESCRIPTION
## Summary
- `_estimate_mp3_duration_ms()` のユニットテスト7件を追加
- `conftest.py` にMP3テストデータ構築ヘルパー (`build_mp3_frame`, `build_id3_header`) と fixture群を追加
- テストケース: MPEG1/MPEG2のms値検証、ID3タグスキップ、ヘッダなし/空/短データ→0
- `docs/evaluation.md` A5セクションを計画中→実装済みに更新

## Test plan
- [x] A5テスト7件全パス
- [x] 全テスト 340 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)