### PR TITLE
refactor: ダミーMP3マジックバイト18箇所をconftest定数に統一

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,6 +60,18 @@ def build_id3_header(tag_size: int = 0) -> bytes:
     return b"ID3" + bytes([0x03, 0x00, 0x00]) + size_bytes + b"\x00" * tag_size
 
 
+# MPEG1 Layer3 128kbps のダミーMP3バイト列（テスト全体で共有）
+# 0xFF 0xFB = sync + MPEG1/Layer3, 0x90 = bitrate_idx=0b1001(128kbps), 0x00 = padding
+DUMMY_MP3_BYTES = build_mp3_frame(mpeg1=True, bitrate_idx=0b1001, audio_size=100)
+DUMMY_MP3_BYTES_SHORT = build_mp3_frame(mpeg1=True, bitrate_idx=0b1001, audio_size=50)
+
+
+@pytest.fixture
+def dummy_mp3() -> bytes:
+    """テスト用ダミーMP3バイト列（MPEG1 128kbps, 104bytes）"""
+    return DUMMY_MP3_BYTES
+
+
 @pytest.fixture
 def sample_outline_md() -> str:
     """基本的なLTアウトラインのMarkdown"""

--- a/tests/test_audio_embedding.py
+++ b/tests/test_audio_embedding.py
@@ -9,6 +9,7 @@ from pptx.opc.package import RT
 from daida_ai.lib.slide_spec import SlideSpec, SlideMetadata, Slide
 from daida_ai.lib.slide_builder import build_presentation
 from daida_ai.lib.audio_embed import embed_audio_to_pptx
+from tests.conftest import DUMMY_MP3_BYTES
 
 
 @pytest.fixture
@@ -34,7 +35,7 @@ def audio_dir(tmp_output_dir: Path) -> Path:
     d = tmp_output_dir / "audio"
     d.mkdir()
     for i in [0, 2]:
-        (d / f"slide_{i:03d}.mp3").write_bytes(b"\xff\xfb\x90\x00" + b"\x00" * 100)
+        (d / f"slide_{i:03d}.mp3").write_bytes(DUMMY_MP3_BYTES)
     return d
 
 

--- a/tests/test_e2e_pipeline.py
+++ b/tests/test_e2e_pipeline.py
@@ -16,6 +16,7 @@ from daida_ai.lib.slide_builder import build_presentation
 from daida_ai.lib.talk_script import read_notes, write_notes
 from daida_ai.lib.audio_embed import embed_audio_to_pptx
 from daida_ai.lib.slideshow import configure_slideshow
+from tests.conftest import DUMMY_MP3_BYTES, DUMMY_MP3_BYTES_SHORT
 
 
 # ── Step 1 相当: Markdownアウトライン ──
@@ -205,9 +206,7 @@ class TestE2EPipeline:
         audio_dir = tmp_output_dir / "audio"
         audio_dir.mkdir()
         for i in [2, 3, 4, 5]:
-            (audio_dir / f"slide_{i:03d}.mp3").write_bytes(
-                b"\xff\xfb\x90\x00" + b"\x00" * 100
-            )
+            (audio_dir / f"slide_{i:03d}.mp3").write_bytes(DUMMY_MP3_BYTES)
 
         # 埋め込み
         output = tmp_output_dir / "final.pptx"
@@ -247,9 +246,7 @@ class TestE2EPipeline:
         audio_dir.mkdir()
         for i in range(6):
             if updated_notes[i]:
-                (audio_dir / f"slide_{i:03d}.mp3").write_bytes(
-                    b"\xff\xfb\x90\x00" + b"\x00" * 50
-                )
+                (audio_dir / f"slide_{i:03d}.mp3").write_bytes(DUMMY_MP3_BYTES_SHORT)
 
         final_path = tmp_output_dir / "final_presentation.pptx"
         count = embed_audio_to_pptx(pptx_path, audio_dir, final_path)

--- a/tests/test_slideshow.py
+++ b/tests/test_slideshow.py
@@ -9,6 +9,7 @@ from daida_ai.lib.slide_spec import SlideSpec, SlideMetadata, Slide
 from daida_ai.lib.slide_builder import build_presentation
 from daida_ai.lib.audio_embed import embed_audio_to_pptx
 from daida_ai.lib.slideshow import configure_slideshow, _estimate_mp3_duration_ms
+from tests.conftest import DUMMY_MP3_BYTES
 
 # OOXML名前空間
 _ns = {
@@ -37,7 +38,7 @@ def pptx_with_audio(tmp_output_dir: Path) -> Path:
     audio_dir = tmp_output_dir / "audio"
     audio_dir.mkdir()
     # ダミーMP3（104バイト）
-    dummy_mp3 = b"\xff\xfb\x90\x00" + b"\x00" * 100
+    dummy_mp3 = DUMMY_MP3_BYTES
     (audio_dir / "slide_001.mp3").write_bytes(dummy_mp3)
     (audio_dir / "slide_003.mp3").write_bytes(dummy_mp3)
 
@@ -219,7 +220,7 @@ class Test既存アニメーション保持:
         # スライド1に音声を埋め込む
         audio_dir = tmp_output_dir / "audio_anim"
         audio_dir.mkdir()
-        dummy_mp3 = b"\xff\xfb\x90\x00" + b"\x00" * 100
+        dummy_mp3 = DUMMY_MP3_BYTES
         (audio_dir / "slide_001.mp3").write_bytes(dummy_mp3)
         with_audio = tmp_output_dir / "with_audio_anim.pptx"
         embed_audio_to_pptx(pptx_path, audio_dir, with_audio)
@@ -900,7 +901,7 @@ class TestLibreOffice互換mainSeqDur:
         audio_dir = tmp_output_dir / "audio_anim_protect"
         audio_dir.mkdir()
         # 約6msのフェイクMP3 (音声長 < 500ms)
-        dummy_mp3 = b"\xff\xfb\x90\x00" + b"\x00" * 100
+        dummy_mp3 = DUMMY_MP3_BYTES
         (audio_dir / "slide_001.mp3").write_bytes(dummy_mp3)
         with_audio = tmp_output_dir / "anim_protect_audio.pptx"
         embed_audio_to_pptx(pptx_path, audio_dir, with_audio)
@@ -989,7 +990,7 @@ class TestLibreOffice互換mainSeqDur:
         audio_dir = tmp_output_dir / "audio_delay_anim"
         audio_dir.mkdir()
         # 約6msのフェイクMP3 (音声長 << 6000ms)
-        dummy_mp3 = b"\xff\xfb\x90\x00" + b"\x00" * 100
+        dummy_mp3 = DUMMY_MP3_BYTES
         (audio_dir / "slide_001.mp3").write_bytes(dummy_mp3)
         with_audio = tmp_output_dir / "delay_anim_audio.pptx"
         embed_audio_to_pptx(pptx_path, audio_dir, with_audio)
@@ -1076,7 +1077,7 @@ class TestLibreOffice互換mainSeqDur:
 
         audio_dir = tmp_output_dir / "audio_nested_delay"
         audio_dir.mkdir()
-        dummy_mp3 = b"\xff\xfb\x90\x00" + b"\x00" * 100
+        dummy_mp3 = DUMMY_MP3_BYTES
         (audio_dir / "slide_001.mp3").write_bytes(dummy_mp3)
         with_audio = tmp_output_dir / "nested_delay_audio.pptx"
         embed_audio_to_pptx(pptx_path, audio_dir, with_audio)
@@ -1171,7 +1172,7 @@ class TestLibreOffice互換mainSeqDur:
         audio_dir = tmp_output_dir / "audio_adv_sync"
         audio_dir.mkdir()
         # 約6msのフェイクMP3 (音声長 << 5000ms アニメーション)
-        dummy_mp3 = b"\xff\xfb\x90\x00" + b"\x00" * 100
+        dummy_mp3 = DUMMY_MP3_BYTES
         (audio_dir / "slide_001.mp3").write_bytes(dummy_mp3)
         with_audio = tmp_output_dir / "adv_sync_audio.pptx"
         embed_audio_to_pptx(pptx_path, audio_dir, with_audio)
@@ -1263,7 +1264,7 @@ class TestLibreOffice互換mainSeqDur:
 
         audio_dir = tmp_output_dir / "audio_event_chain"
         audio_dir.mkdir()
-        dummy_mp3 = b"\xff\xfb\x90\x00" + b"\x00" * 100
+        dummy_mp3 = DUMMY_MP3_BYTES
         (audio_dir / "slide_001.mp3").write_bytes(dummy_mp3)
         with_audio = tmp_output_dir / "event_chain_audio.pptx"
         embed_audio_to_pptx(pptx_path, audio_dir, with_audio)
@@ -1453,7 +1454,7 @@ class TestLibreOffice互換mainSeqDur:
 
         audio_dir = tmp_output_dir / "audio_onbegin"
         audio_dir.mkdir()
-        dummy_mp3 = b"\xff\xfb\x90\x00" + b"\x00" * 100
+        dummy_mp3 = DUMMY_MP3_BYTES
         (audio_dir / "slide_001.mp3").write_bytes(dummy_mp3)
         with_audio = tmp_output_dir / "onbegin_audio.pptx"
         embed_audio_to_pptx(pptx_path, audio_dir, with_audio)
@@ -1569,7 +1570,7 @@ class TestLibreOffice互換mainSeqDur:
         audio_dir = tmp_output_dir / "audio_repeat"
         audio_dir.mkdir()
         # 音声長 << 3000ms
-        dummy_mp3 = b"\xff\xfb\x90\x00" + b"\x00" * 100
+        dummy_mp3 = DUMMY_MP3_BYTES
         (audio_dir / "slide_001.mp3").write_bytes(dummy_mp3)
         with_audio = tmp_output_dir / "repeat_audio.pptx"
         embed_audio_to_pptx(pptx_path, audio_dir, with_audio)
@@ -1666,7 +1667,7 @@ class TestLibreOffice互換mainSeqDur:
         audio_dir = tmp_output_dir / "audio_onclick"
         audio_dir.mkdir()
         # 約6msのフェイクMP3
-        dummy_mp3 = b"\xff\xfb\x90\x00" + b"\x00" * 100
+        dummy_mp3 = DUMMY_MP3_BYTES
         (audio_dir / "slide_001.mp3").write_bytes(dummy_mp3)
         with_audio = tmp_output_dir / "onclick_audio.pptx"
         embed_audio_to_pptx(pptx_path, audio_dir, with_audio)
@@ -1758,7 +1759,7 @@ class TestLibreOffice互換mainSeqDur:
 
         audio_dir = tmp_output_dir / "audio_repeatdur"
         audio_dir.mkdir()
-        dummy_mp3 = b"\xff\xfb\x90\x00" + b"\x00" * 100
+        dummy_mp3 = DUMMY_MP3_BYTES
         (audio_dir / "slide_001.mp3").write_bytes(dummy_mp3)
         with_audio = tmp_output_dir / "repeatdur_audio.pptx"
         embed_audio_to_pptx(pptx_path, audio_dir, with_audio)
@@ -1844,7 +1845,7 @@ class TestLibreOffice互換mainSeqDur:
 
         audio_dir = tmp_output_dir / "audio_repeat_indef"
         audio_dir.mkdir()
-        dummy_mp3 = b"\xff\xfb\x90\x00" + b"\x00" * 100
+        dummy_mp3 = DUMMY_MP3_BYTES
         (audio_dir / "slide_001.mp3").write_bytes(dummy_mp3)
         with_audio = tmp_output_dir / "repeat_indef_audio.pptx"
         embed_audio_to_pptx(pptx_path, audio_dir, with_audio)
@@ -1930,7 +1931,7 @@ class TestLibreOffice互換mainSeqDur:
 
         audio_dir = tmp_output_dir / "audio_cycle"
         audio_dir.mkdir()
-        dummy_mp3 = b"\xff\xfb\x90\x00" + b"\x00" * 100
+        dummy_mp3 = DUMMY_MP3_BYTES
         (audio_dir / "slide_001.mp3").write_bytes(dummy_mp3)
         with_audio = tmp_output_dir / "cycle_audio.pptx"
         embed_audio_to_pptx(pptx_path, audio_dir, with_audio)

--- a/tests/test_synthesize_audio.py
+++ b/tests/test_synthesize_audio.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 from daida_ai.lib.synthesize import synthesize_notes
+from tests.conftest import DUMMY_MP3_BYTES_SHORT
 
 
 @pytest.fixture
@@ -18,7 +19,7 @@ def mock_engine():
 
     async def fake_synthesize(text, output_path, voice=None):
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        output_path.write_bytes(b"\xff\xfb\x90\x00" + b"\x00" * 50)
+        output_path.write_bytes(DUMMY_MP3_BYTES_SHORT)
         return output_path
 
     engine.synthesize.side_effect = fake_synthesize
@@ -211,7 +212,7 @@ class TestA4_TTS障害時フォールバック:
             if call_count == 2:
                 raise ConnectionError("VOICEVOX connection refused")
             output_path.parent.mkdir(parents=True, exist_ok=True)
-            output_path.write_bytes(b"\xff\xfb\x90\x00" + b"\x00" * 50)
+            output_path.write_bytes(DUMMY_MP3_BYTES_SHORT)
             return output_path
 
         engine.synthesize.side_effect = partial_fail


### PR DESCRIPTION
## Summary
- テスト全体に散在していた `b"\xff\xfb\x90\x00" + b"\x00" * N` (18箇所) を `conftest.py` の `DUMMY_MP3_BYTES` / `DUMMY_MP3_BYTES_SHORT` に統一
- `build_mp3_frame()` で生成したバイト列と既存マジックバイトの完全一致を確認済み
- 動作変更なし（pure refactoring）

## Test plan
- [x] 全テスト 340 passed, 1 skipped（変更前と同一）
- [x] `rg "\\xff\\xfb\\x90\\x00" tests/` → No matches（マジックバイト完全排除確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)