### PR TITLE
fix: defusedxml を依存に明示追加

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "pydub>=0.25.1",
     "audioop-lts>=0.2.1",
     "Pillow>=10.0.0",
+    "defusedxml>=0.7.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- PR #50 で導入した `defusedxml` (XML Billion Laughs DoS防御) を `pyproject.toml` の依存に明示追加

## Test plan

- [x] 全テスト 380 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)