### PR TITLE
fix: audioop-lts を Python 3.13+ 限定の条件付き依存に変更

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
     "python-pptx>=1.0.0",
     "edge-tts>=6.1.0",
     "pydub>=0.25.1",
-    "audioop-lts>=0.2.1",
+    "audioop-lts>=0.2.1; python_version >= '3.13'",
     "Pillow>=10.0.0",
     "defusedxml>=0.7.0",
 ]


### PR DESCRIPTION
## Summary

- `audioop-lts>=0.2.1` に `python_version >= '3.13'` の条件を追加
- Python 3.12 以下での `setup.sh` 実行失敗を修正

## 背景

`audioop` モジュールは Python 3.12 以下では標準ライブラリに含まれており、`audioop-lts` は不要。
しかし `audioop-lts>=0.2.1` の全バージョンが `Requires-Python >=3.13` を宣言しているため、
Python 3.12 環境では `pip install` が失敗し `setup.sh` がエラー終了していた。

## Test plan

- [ ] Python 3.12 環境で `setup.sh` が正常完了することを確認
- [ ] Python 3.13 環境で引き続き `audioop-lts` がインストールされることを確認
- [ ] `edge-tts` の音声合成が Python 3.12/3.13 両環境で動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)