### PR TITLE
fix: SVG→PPTX埋め込み時の日本語テキスト豆腐化を修正

### DIFF
--- a/daida_ai/lib/svg_convert.py
+++ b/daida_ai/lib/svg_convert.py
@@ -228,6 +228,11 @@ def inject_japanese_fonts(svg_content: str) -> str:
     対応箇所:
     - font-family="..." 属性 (ダブル/シングルクォート)
     - style="... font-family: ...; ..." インラインスタイル
+
+    非対応（意図的）:
+    - <style> ブロック内の @font-face { font-family: ... } — フェース名宣言への
+      誤注入を避けるため、<style> ブロックは変更しない。
+      このプロジェクトが生成するSVGは <style> ブロックを使わないため問題ない。
     """
     def _needs_injection(families: str) -> bool:
         return not any(kw in families.lower() for kw in _JP_FONT_KEYWORDS)
@@ -241,16 +246,26 @@ def inject_japanese_fonts(svg_content: str) -> str:
 
     def _rewrite_style(m: re.Match) -> str:
         prop_name = m.group(1)
-        families = m.group(2)
+        families = m.group(2).rstrip()
         if not _needs_injection(families):
             return m.group(0)
         return f'{prop_name}{_JP_FONT_FALLBACK}{families}'
+
+    # <style> ブロックを一時的にプレースホルダに退避して正規表現の誤爆を防ぐ
+    style_blocks: list[str] = []
+
+    def _stash_style(m: re.Match) -> str:
+        style_blocks.append(m.group(0))
+        return f'__STYLE_BLOCK_{len(style_blocks) - 1}__'
+
+    result = re.sub(r'<style[^>]*>.*?</style>', _stash_style, svg_content,
+                    flags=re.DOTALL | re.IGNORECASE)
 
     # font-family="..." 属性
     result = re.sub(
         r'font-family=(["\'])([^"\']+)\1',
         _rewrite_attr,
-        svg_content,
+        result,
     )
     # style="... font-family: ...; ..." インラインスタイル
     result = re.sub(
@@ -258,6 +273,11 @@ def inject_japanese_fonts(svg_content: str) -> str:
         _rewrite_style,
         result,
     )
+
+    # 退避した <style> ブロックを復元
+    for i, block in enumerate(style_blocks):
+        result = result.replace(f'__STYLE_BLOCK_{i}__', block)
+
     return result
 
 
@@ -300,10 +320,14 @@ def convert_svg_to_png(
     try:
         svg_bytes = path.read_bytes()
         if _inject_japanese_fonts_enabled:
-            svg_text = inject_japanese_fonts(svg_bytes.decode("utf-8", errors="replace"))
+            # このプロジェクトが生成するSVGは常にUTF-8。
+            # bytestring でフォント注入済みSVGを渡しつつ、url を base URI として
+            # 同時指定することで相対パス（<image href="..."> 等）の解決を維持する。
+            svg_text = inject_japanese_fonts(svg_bytes.decode("utf-8"))
             svg_bytes = svg_text.encode("utf-8")
         _cairosvg.svg2png(
             bytestring=svg_bytes,
+            url=str(path.resolve()),
             write_to=output_path,
             scale=scale,
         )

--- a/daida_ai/lib/svg_convert.py
+++ b/daida_ai/lib/svg_convert.py
@@ -21,6 +21,19 @@ try:
 except ImportError:
     _cairosvg = None
 
+# inject_japanese_fonts の有効/無効フラグ（テスト用）
+_inject_japanese_fonts_enabled = True
+
+# cairosvg/fontconfig が日本語グリフを持つと確認済みのフォントリスト
+# 優先順位: macOS (Hiragino) > Windows (Yu Gothic) > Linux (Noto CJK) > fallback
+_JP_FONT_FALLBACK = (
+    "Hiragino Sans, Hiragino Kaku Gothic ProN, Hiragino Kaku Gothic Pro, "
+    "Yu Gothic, Meiryo, Noto Sans CJK JP, Noto Serif CJK JP, "
+)
+
+# 既に日本語フォントが含まれていると見なすキーワード
+_JP_FONT_KEYWORDS = ("hiragino", "yu gothic", "meiryo", "noto sans cjk", "noto serif cjk")
+
 
 class SVGConversionError(Exception):
     """SVG変換に失敗した場合の例外"""
@@ -203,6 +216,51 @@ def validate_svg_font_sizes(
     return violations
 
 
+def inject_japanese_fonts(svg_content: str) -> str:
+    """SVG内の font-family 属性に日本語フォントのフォールバックを注入する。
+
+    cairosvg/libcairo は font-family="sans-serif" を Noto Sans（CJKグリフなし）に
+    解決するため、日本語テキストが豆腐（□）になる。日本語対応フォントを先頭に
+    追加することで、fontconfig が正しいフォントを選択できるようにする。
+
+    既に Hiragino / Yu Gothic / Meiryo / Noto CJK が含まれている場合は変更しない。
+
+    対応箇所:
+    - font-family="..." 属性 (ダブル/シングルクォート)
+    - style="... font-family: ...; ..." インラインスタイル
+    """
+    def _needs_injection(families: str) -> bool:
+        return not any(kw in families.lower() for kw in _JP_FONT_KEYWORDS)
+
+    def _rewrite_attr(m: re.Match) -> str:
+        quote = m.group(1)
+        families = m.group(2)
+        if not _needs_injection(families):
+            return m.group(0)
+        return f'font-family={quote}{_JP_FONT_FALLBACK}{families}{quote}'
+
+    def _rewrite_style(m: re.Match) -> str:
+        prop_name = m.group(1)
+        families = m.group(2)
+        if not _needs_injection(families):
+            return m.group(0)
+        return f'{prop_name}{_JP_FONT_FALLBACK}{families}'
+
+    # font-family="..." 属性
+    result = re.sub(
+        r'font-family=(["\'])([^"\']+)\1',
+        _rewrite_attr,
+        svg_content,
+    )
+    # style="... font-family: ...; ..." インラインスタイル
+    result = re.sub(
+        r'(font-family\s*:\s*)([^;"\'>]+)',
+        _rewrite_style,
+        result,
+    )
+    return result
+
+
 def convert_svg_to_png(
     svg_path: str,
     output_path: str | None = None,
@@ -240,8 +298,12 @@ def convert_svg_to_png(
         Path(output_path).parent.mkdir(parents=True, exist_ok=True)
 
     try:
+        svg_bytes = path.read_bytes()
+        if _inject_japanese_fonts_enabled:
+            svg_text = inject_japanese_fonts(svg_bytes.decode("utf-8", errors="replace"))
+            svg_bytes = svg_text.encode("utf-8")
         _cairosvg.svg2png(
-            url=str(path.resolve()),
+            bytestring=svg_bytes,
             write_to=output_path,
             scale=scale,
         )

--- a/daida_ai/lib/svg_convert.py
+++ b/daida_ai/lib/svg_convert.py
@@ -251,12 +251,15 @@ def inject_japanese_fonts(svg_content: str) -> str:
             return m.group(0)
         return f'{prop_name}{_JP_FONT_FALLBACK}{families}'
 
-    # <style> ブロックを一時的にプレースホルダに退避して正規表現の誤爆を防ぐ
+    # <style> ブロックを一時的にプレースホルダに退避して正規表現の誤爆を防ぐ。
+    # UUID をセッション固有のプレフィックスとして使い、SVG内容との衝突を防ぐ。
+    import uuid
+    _session_id = uuid.uuid4().hex
     style_blocks: list[str] = []
 
     def _stash_style(m: re.Match) -> str:
         style_blocks.append(m.group(0))
-        return f'__STYLE_BLOCK_{len(style_blocks) - 1}__'
+        return f'__SVG_STYLE_{_session_id}_{len(style_blocks) - 1}__'
 
     result = re.sub(r'<style[^>]*>.*?</style>', _stash_style, svg_content,
                     flags=re.DOTALL | re.IGNORECASE)
@@ -276,7 +279,7 @@ def inject_japanese_fonts(svg_content: str) -> str:
 
     # 退避した <style> ブロックを復元
     for i, block in enumerate(style_blocks):
-        result = result.replace(f'__STYLE_BLOCK_{i}__', block)
+        result = result.replace(f'__SVG_STYLE_{_session_id}_{i}__', block)
 
     return result
 
@@ -323,8 +326,15 @@ def convert_svg_to_png(
             # このプロジェクトが生成するSVGは常にUTF-8。
             # bytestring でフォント注入済みSVGを渡しつつ、url を base URI として
             # 同時指定することで相対パス（<image href="..."> 等）の解決を維持する。
-            svg_text = inject_japanese_fonts(svg_bytes.decode("utf-8"))
-            svg_bytes = svg_text.encode("utf-8")
+            # UTF-8以外のSVGは稀なケースとして注入をスキップし、元バイト列をそのまま使う。
+            try:
+                svg_text = inject_japanese_fonts(svg_bytes.decode("utf-8"))
+                svg_bytes = svg_text.encode("utf-8")
+            except UnicodeDecodeError:
+                logger.warning(
+                    "SVG is not valid UTF-8; skipping Japanese font injection: %s",
+                    svg_path,
+                )
         _cairosvg.svg2png(
             bytestring=svg_bytes,
             url=str(path.resolve()),

--- a/skills/daida-ai/SKILL.md
+++ b/skills/daida-ai/SKILL.md
@@ -329,7 +329,7 @@ rendered_pt = f_svg × display_w_emu / (viewBox_w × 12700)
 | casual | `#FFF8F0` | `#FF6B35` | `#06D6A0` | `#2D3748` |
 | formal | `#FFFFFF` | `#1B2D45` | `#C49B66` | `#1B2D45` |
 
-**注意**: フォントは必ず `font-family="sans-serif"` を指定する（環境依存を避けるため）。
+**注意**: フォントは必ず `font-family="sans-serif"` を指定する。cairosvg が自動的に日本語フォントのフォールバックを注入するため、日本語テキストが豆腐（□）になることはない。`font-family` に `Hiragino` / `Yu Gothic` / `Noto Sans CJK JP` などを既に含む場合は注入をスキップする。
 
 #### SVGパターン集
 

--- a/tests/test_svg_to_png.py
+++ b/tests/test_svg_to_png.py
@@ -155,17 +155,34 @@ class TestSVGContent:
 
         豆腐判定: sans-serif のみで変換した PNG と比較して画素が異なることを確認する。
         (sans-serif → Noto Sans → CJKグリフなし → 豆腐 が既知の状態)
+
+        環境依存注記: このテストは「sans-serif が CJK グリフなしフォントに解決される」
+        かつ「注入フォント（Hiragino 等）が利用可能」な環境でのみ意味を持つ。
+        どちらかの条件が満たされない場合（CI 等）は skip される。
         """
+        import shutil
         from PIL import Image
 
-        svg_sans = """\
-<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200">
-  <rect width="400" height="200" fill="#1E293B"/>
-  <text x="200" y="110" text-anchor="middle" fill="white"
-        font-size="40" font-family="sans-serif">日本語テスト</text>
-</svg>
-"""
-        svg_japanese = """\
+        # fc-match で sans-serif の解決先を確認 — CJK フォントに解決される環境では skip
+        fc_match = shutil.which("fc-match")
+        if fc_match is None:
+            pytest.skip("fontconfig (fc-match) が利用できないため skip")
+
+        import subprocess
+        sans_font = subprocess.run(
+            ["fc-match", "sans-serif", "--format=%{family}"],
+            capture_output=True, text=True,
+        ).stdout.strip().lower()
+        jp_font = subprocess.run(
+            ["fc-match", "sans-serif:lang=ja", "--format=%{family}"],
+            capture_output=True, text=True,
+        ).stdout.strip().lower()
+        if sans_font == jp_font:
+            pytest.skip(
+                f"sans-serif が既に日本語フォント ({jp_font}) に解決されるため skip"
+            )
+
+        svg_content = """\
 <svg xmlns="http://www.w3.org/2000/svg" width="400" height="200">
   <rect width="400" height="200" fill="#1E293B"/>
   <text x="200" y="110" text-anchor="middle" fill="white"
@@ -174,7 +191,7 @@ class TestSVGContent:
 """
         # 修正前: font-family="sans-serif" のみ (豆腐の基準)
         svg_tofu_path = tmp_path / "tofu.svg"
-        svg_tofu_path.write_text(svg_sans, encoding="utf-8")
+        svg_tofu_path.write_text(svg_content, encoding="utf-8")
         png_tofu = tmp_path / "tofu.png"
 
         import daida_ai.lib.svg_convert as mod
@@ -187,14 +204,13 @@ class TestSVGContent:
 
         # 修正後: inject_japanese_fonts が適用された状態
         svg_fixed_path = tmp_path / "fixed.svg"
-        svg_fixed_path.write_text(svg_japanese, encoding="utf-8")
+        svg_fixed_path.write_text(svg_content, encoding="utf-8")
         png_fixed = tmp_path / "fixed.png"
         convert_svg_to_png(str(svg_fixed_path), str(png_fixed))
 
-        # 豆腐PNGと修正後PNGは異なるはず
-        tofu_data = list(Image.open(png_tofu).convert("RGB").getdata())
-        fixed_data = list(Image.open(png_fixed).convert("RGB").getdata())
-        assert tofu_data != fixed_data, "日本語フォントが注入されず豆腐になっています"
+        tofu_pixels = list(Image.open(png_tofu).convert("RGB").getdata())
+        fixed_pixels = list(Image.open(png_fixed).convert("RGB").getdata())
+        assert tofu_pixels != fixed_pixels, "日本語フォントが注入されず豆腐になっています"
 
     def test_16_9アスペクト比のSVG(self, tmp_path):
         """スライド全面用の16:9 SVG"""
@@ -275,3 +291,25 @@ class TestInjectJapaneseFonts:
         svg = '<text font-family="Arial, sans-serif">テスト</text>'
         result = inject_japanese_fonts(svg)
         assert "Hiragino" in result
+
+    def test_styleブロック内のfont_familyは変更しない(self):
+        """<style> ブロック内の @font-face font-family 宣言は変更しない"""
+        svg = (
+            '<style>.x { font-family: sans-serif; }</style>'
+            '<text font-family="sans-serif">テスト</text>'
+        )
+        result = inject_japanese_fonts(svg)
+        # <style> 内は変更しない
+        assert '<style>.x { font-family: sans-serif; }</style>' in result
+        # <text> 属性には注入される
+        assert 'Hiragino' in result.split('</style>')[1]
+
+    def test_at_font_face宣言のfont_familyは変更しない(self):
+        """@font-face ブロック内の font-family フェース名は変更しない"""
+        svg = (
+            '<style>@font-face { font-family: "MyFont"; src: url(foo.ttf); }</style>'
+            '<text font-family="sans-serif">テスト</text>'
+        )
+        result = inject_japanese_fonts(svg)
+        assert '"MyFont"' in result  # フェース名が壊れていない
+        assert 'Hiragino' in result.split('</style>')[1]

--- a/tests/test_svg_to_png.py
+++ b/tests/test_svg_to_png.py
@@ -3,7 +3,11 @@
 from pathlib import Path
 import pytest
 
-from daida_ai.lib.svg_convert import convert_svg_to_png, SVGConversionError
+from daida_ai.lib.svg_convert import (
+    convert_svg_to_png,
+    SVGConversionError,
+    inject_japanese_fonts,
+)
 
 
 # テスト用SVG
@@ -146,6 +150,52 @@ class TestSVGContent:
         assert Path(result).exists()
         assert Path(result).read_bytes()[:4] == b"\x89PNG"
 
+    def test_日本語テキストを含むSVGが豆腐にならない(self, tmp_path):
+        """font-family="sans-serif"のSVGでも日本語フォントが自動注入されて豆腐にならない。
+
+        豆腐判定: sans-serif のみで変換した PNG と比較して画素が異なることを確認する。
+        (sans-serif → Noto Sans → CJKグリフなし → 豆腐 が既知の状態)
+        """
+        from PIL import Image
+
+        svg_sans = """\
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200">
+  <rect width="400" height="200" fill="#1E293B"/>
+  <text x="200" y="110" text-anchor="middle" fill="white"
+        font-size="40" font-family="sans-serif">日本語テスト</text>
+</svg>
+"""
+        svg_japanese = """\
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200">
+  <rect width="400" height="200" fill="#1E293B"/>
+  <text x="200" y="110" text-anchor="middle" fill="white"
+        font-size="40" font-family="sans-serif">日本語テスト</text>
+</svg>
+"""
+        # 修正前: font-family="sans-serif" のみ (豆腐の基準)
+        svg_tofu_path = tmp_path / "tofu.svg"
+        svg_tofu_path.write_text(svg_sans, encoding="utf-8")
+        png_tofu = tmp_path / "tofu.png"
+
+        import daida_ai.lib.svg_convert as mod
+        original = mod._inject_japanese_fonts_enabled
+        try:
+            mod._inject_japanese_fonts_enabled = False
+            convert_svg_to_png(str(svg_tofu_path), str(png_tofu))
+        finally:
+            mod._inject_japanese_fonts_enabled = original
+
+        # 修正後: inject_japanese_fonts が適用された状態
+        svg_fixed_path = tmp_path / "fixed.svg"
+        svg_fixed_path.write_text(svg_japanese, encoding="utf-8")
+        png_fixed = tmp_path / "fixed.png"
+        convert_svg_to_png(str(svg_fixed_path), str(png_fixed))
+
+        # 豆腐PNGと修正後PNGは異なるはず
+        tofu_data = list(Image.open(png_tofu).convert("RGB").getdata())
+        fixed_data = list(Image.open(png_fixed).convert("RGB").getdata())
+        assert tofu_data != fixed_data, "日本語フォントが注入されず豆腐になっています"
+
     def test_16_9アスペクト比のSVG(self, tmp_path):
         """スライド全面用の16:9 SVG"""
         svg = """\
@@ -161,3 +211,67 @@ class TestSVGContent:
         result = convert_svg_to_png(str(svg_path), str(png_path))
 
         assert Path(result).exists()
+
+
+class TestInjectJapaneseFonts:
+    """inject_japanese_fonts — font-family への日本語フォント自動注入"""
+
+    def test_sans_serifに日本語フォントが先頭に注入される(self):
+        svg = '<text font-family="sans-serif">テスト</text>'
+        result = inject_japanese_fonts(svg)
+        assert result.startswith('<text font-family="') or 'font-family=' in result
+        assert "Hiragino" in result
+        assert "sans-serif" in result
+
+    def test_注入後もsans_serifが末尾に残る(self):
+        svg = '<text font-family="sans-serif">テスト</text>'
+        result = inject_japanese_fonts(svg)
+        # sans-serif はフォールバックとして末尾に残すべき
+        families = result.split('font-family="')[1].split('"')[0]
+        assert families.strip().endswith("sans-serif")
+
+    def test_既にHiraginoが含まれている場合は変更しない(self):
+        svg = '<text font-family="Hiragino Sans, sans-serif">テスト</text>'
+        result = inject_japanese_fonts(svg)
+        assert result == svg
+
+    def test_既にYu_Gothicが含まれている場合は変更しない(self):
+        svg = '<text font-family="Yu Gothic, sans-serif">テスト</text>'
+        result = inject_japanese_fonts(svg)
+        assert result == svg
+
+    def test_既にNoto_Sans_CJKが含まれている場合は変更しない(self):
+        svg = '<text font-family="Noto Sans CJK JP, sans-serif">テスト</text>'
+        result = inject_japanese_fonts(svg)
+        assert result == svg
+
+    def test_font_familyなしの要素は変更しない(self):
+        svg = '<text>テスト</text>'
+        result = inject_japanese_fonts(svg)
+        assert result == svg
+
+    def test_inline_styleのfont_familyにも注入される(self):
+        svg = '<text style="font-size:40px; font-family: sans-serif;">テスト</text>'
+        result = inject_japanese_fonts(svg)
+        assert "Hiragino" in result
+
+    def test_複数のtext要素すべてに注入される(self):
+        svg = (
+            '<text font-family="sans-serif">A</text>'
+            '<text font-family="sans-serif">B</text>'
+        )
+        result = inject_japanese_fonts(svg)
+        # 元の font-family="sans-serif" がそのまま残っていないこと（両方注入済み）
+        assert result.count('font-family="sans-serif"') == 0
+        assert "Hiragino" in result
+
+    def test_シングルクォートのfont_familyにも注入される(self):
+        svg = "<text font-family='sans-serif'>テスト</text>"
+        result = inject_japanese_fonts(svg)
+        assert "Hiragino" in result
+
+    def test_欧文のみのfont_familyにも注入される(self):
+        """欧文フォント指定でも注入する（日本語が混入するSVGに対応）"""
+        svg = '<text font-family="Arial, sans-serif">テスト</text>'
+        result = inject_japanese_fonts(svg)
+        assert "Hiragino" in result


### PR DESCRIPTION
## 概要

SVGをcairosvgでPNGに変換してPPTXに埋め込む際、日本語テキストが豆腐（□）になる問題を修正する。

## 原因

`font-family="sans-serif"` は cairosvg → libcairo → fontconfig の変換パイプラインで **Noto Sans（CJKグリフなし）** に解決される。

- Chrome: Unicode範囲フォールバックで自動的にCJKフォントを選択 → 正常表示
- cairosvg: `font-family` 名のみで fontconfig に問い合わせ → CJKグリフなしフォント → 豆腐

`xml:lang="ja"` は cairosvg/libcairo に伝播しないため効果なし（実測済み）。

## 修正内容

`svg_convert.py` に `inject_japanese_fonts()` を追加し、`convert_svg_to_png()` 実行前に `font-family` へ日本語対応フォントのフォールバックチェーンを自動注入する。

```
Hiragino Sans (macOS) > Yu Gothic (Windows) > Noto Sans CJK JP (Linux) > sans-serif
```

- `font-family` 属性（ダブル/シングルクォート）および `style` 属性のインライン指定の両方に対応
- 既に `Hiragino` / `Yu Gothic` / `Meiryo` / `Noto CJK` が含まれている場合はスキップ
- テスト用フラグ `_inject_japanese_fonts_enabled` でオン/オフ切り替え可能

## テスト

- `TestInjectJapaneseFonts` — `inject_japanese_fonts()` のユニットテスト 10件追加
- `test_日本語テキストを含むSVGが豆腐にならない` — PILピクセル比較で豆腐かどうかを検証する統合テスト追加

## Test plan

- [ ] `tests/test_svg_to_png.py` が全件パスすること（22件）
- [ ] 修正前（`sans-serif` のみ）と修正後の PNG が異なること（ピクセル比較）
- [ ] 既に日本語フォントを指定したSVGが変更されないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)