### PR TITLE
chore: バージョンを 0.2.1 にバンプ

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "daida-ai",
   "description": "LTプレゼン自動生成 — テーマからスライド・音声ナレーション付きPPTXまで一括対応",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": {
     "name": "hawkymisc"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "daida-ai"
-version = "0.2.0"
+version = "0.2.1"
 description = "LT presentation auto-generation Agent Skill"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary

- `pyproject.toml` および `.claude-plugin/plugin.json` のバージョンを `0.2.0` → `0.2.1` に更新

## 含まれる変更 (since 0.2.0)

- PR #55: `audioop-lts` を Python 3.13+ 限定の条件付き依存に変更（Python 3.12 対応）
- PR #58: SVG→PPTX埋め込み時の日本語テキスト豆腐化を修正（`inject_japanese_fonts()`）

## Test plan

- [ ] `/plugin install daida-ai@hawkymisc-daida-ai` でキャッシュが 0.2.1 に更新されることを確認
- [ ] `/daida-ai:daida-ai` で日本語SVG入りスライドが豆腐にならないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)