### PR TITLE
feat: slide_specバリデーション7項目を強化

### DIFF
--- a/daida_ai/lib/slide_spec.py
+++ b/daida_ai/lib/slide_spec.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import warnings
 from dataclasses import dataclass, field, asdict
 from pathlib import Path
 
@@ -18,6 +19,8 @@ TITLE_EXEMPT_LAYOUTS = {"blank"}
 MAX_TITLE_LENGTH = 100
 MAX_SUBTITLE_LENGTH = 200
 MAX_BODY_ITEM_LENGTH = 200
+MAX_NOTE_LENGTH = 10000
+MAX_HEADING_LENGTH = 100
 
 VALID_TEMPLATES = {"tech", "casual", "formal"}
 VALID_LAYOUTS = {
@@ -27,6 +30,21 @@ VALID_LAYOUTS = {
     "two_content",
     "title_only",
     "blank",
+}
+
+# レイアウトごとのフィールド定義: 必須 / 任意 / 禁止
+# body, left, right のみ制御（title, note, image, subtitle は別途チェック）
+_LAYOUT_REQUIRED_FIELDS: dict[str, set[str]] = {
+    "two_content": {"left", "right"},
+    "title_and_content": {"body"},
+}
+_LAYOUT_FORBIDDEN_FIELDS: dict[str, set[str]] = {
+    "title_slide": {"body", "left", "right"},
+    "section_header": {"body", "left", "right"},
+    "title_only": {"body", "left", "right"},
+    "blank": {"body", "left", "right"},
+    "title_and_content": {"left", "right"},
+    "two_content": {"body"},
 }
 
 
@@ -109,6 +127,32 @@ def _parse_slide(data: dict) -> Slide:
     )
 
 
+def _validate_layout_fields(idx: int, slide: Slide) -> None:
+    """レイアウトに対するフィールドの必須/禁止チェック。"""
+    layout = slide.layout
+    field_values = {
+        "body": slide.body,
+        "left": slide.left,
+        "right": slide.right,
+    }
+
+    # 必須フィールドチェック
+    for field_name in _LAYOUT_REQUIRED_FIELDS.get(layout, set()):
+        if field_values[field_name] is None:
+            raise ValueError(
+                f"slide[{idx}] (layout={layout}): "
+                f"'{field_name}' is required for this layout"
+            )
+
+    # 禁止フィールドチェック
+    for field_name in _LAYOUT_FORBIDDEN_FIELDS.get(layout, set()):
+        if field_values[field_name] is not None:
+            raise ValueError(
+                f"slide[{idx}] (layout={layout}): "
+                f"'{field_name}' is not supported for this layout"
+            )
+
+
 def validate_slide_spec(
     data: dict,
     *,
@@ -133,10 +177,22 @@ def validate_slide_spec(
     meta_raw = data["metadata"]
     if "title" not in meta_raw:
         raise ValueError("metadata requires 'title' field")
+    meta_subtitle = meta_raw.get("subtitle", "")
+    meta_event = meta_raw.get("event", "")
+    if len(meta_subtitle) > MAX_SUBTITLE_LENGTH:
+        raise ValueError(
+            f"metadata.subtitle exceeds {MAX_SUBTITLE_LENGTH} chars "
+            f"(got {len(meta_subtitle)})"
+        )
+    if len(meta_event) > MAX_SUBTITLE_LENGTH:
+        raise ValueError(
+            f"metadata.event exceeds {MAX_SUBTITLE_LENGTH} chars "
+            f"(got {len(meta_event)})"
+        )
     metadata = SlideMetadata(
         title=meta_raw["title"],
-        subtitle=meta_raw.get("subtitle", ""),
-        event=meta_raw.get("event", ""),
+        subtitle=meta_subtitle,
+        event=meta_event,
         template=meta_raw.get("template", "tech"),
     )
 
@@ -153,8 +209,20 @@ def validate_slide_spec(
             f"slides must have at most {max_slides} slides, got {len(slides)}"
         )
 
+    # 先頭スライドのレイアウト推奨チェック
+    if slides and slides[0].layout != "title_slide":
+        warnings.warn(
+            f"slides[0] layout is '{slides[0].layout}', not 'title_slide'. "
+            f"Consider starting with a title_slide for a proper presentation.",
+            UserWarning,
+            stacklevel=2,
+        )
+
     # 各スライドのバリデーション
     for i, slide in enumerate(slides):
+        # レイアウト-フィールド整合性チェック
+        _validate_layout_fields(i, slide)
+
         # タイトル非空チェック（blankレイアウトは免除）
         if slide.layout not in TITLE_EXEMPT_LAYOUTS:
             if not slide.title or not slide.title.strip():
@@ -181,6 +249,20 @@ def validate_slide_spec(
                     f"slide[{i}] (layout={slide.layout}) requires a non-empty note"
                 )
 
+        # ノート文字数上限
+        if slide.note and len(slide.note) > MAX_NOTE_LENGTH:
+            raise ValueError(
+                f"slide[{i}] note exceeds {MAX_NOTE_LENGTH} chars "
+                f"(got {len(slide.note)})"
+            )
+
+        # image 空文字列チェック
+        if slide.image is not None and not slide.image.strip():
+            raise ValueError(
+                f"slide[{i}] image must not be empty string "
+                f"(use null/None to omit)"
+            )
+
         # 情報密度チェック（bodyがある場合のみ）
         if slide.body is not None:
             if len(slide.body) < MIN_BODY_ITEMS:
@@ -200,13 +282,28 @@ def validate_slide_spec(
                         f"(got {len(item)})"
                     )
 
-        # 2カラムレイアウトのbody検証
+        # 2カラムレイアウトの詳細検証
         for col_name, col in [("left", slide.left), ("right", slide.right)]:
-            if col is not None and col.body:
-                if len(col.body) > MAX_BODY_ITEMS:
+            if col is None:
+                continue
+            # heading 長チェック
+            if len(col.heading) > MAX_HEADING_LENGTH:
+                raise ValueError(
+                    f"slide[{i}] {col_name}.heading exceeds "
+                    f"{MAX_HEADING_LENGTH} chars (got {len(col.heading)})"
+                )
+            # body 件数チェック
+            if col.body and len(col.body) > MAX_BODY_ITEMS:
+                raise ValueError(
+                    f"slide[{i}] {col_name}.body must have at most "
+                    f"{MAX_BODY_ITEMS} items, got {len(col.body)}"
+                )
+            # body 項目文字数チェック
+            for j, item in enumerate(col.body):
+                if len(item) > MAX_BODY_ITEM_LENGTH:
                     raise ValueError(
-                        f"slide[{i}] {col_name}.body must have at most "
-                        f"{MAX_BODY_ITEMS} items, got {len(col.body)}"
+                        f"slide[{i}] {col_name}.body[{j}] exceeds "
+                        f"{MAX_BODY_ITEM_LENGTH} chars (got {len(item)})"
                     )
 
     # 推定発話時間チェック

--- a/tests/test_pptx_robustness.py
+++ b/tests/test_pptx_robustness.py
@@ -24,10 +24,9 @@ def _make_valid_spec(*, title="テスト", body=None, subtitle=None):
     slide = {
         "layout": "title_and_content",
         "title": title,
+        "body": body if body is not None else ["デフォルト項目"],
         "note": "テスト用のノートです",
     }
-    if body is not None:
-        slide["body"] = body
     if subtitle is not None:
         slide["subtitle"] = subtitle
     return {

--- a/tests/test_slide_spec_validation.py
+++ b/tests/test_slide_spec_validation.py
@@ -1,0 +1,292 @@
+"""TDD: slide_spec バリデーション強化テスト
+
+レイアウト-フィールド整合性、テキスト長チェック、
+その他の未実装バリデーションを検証する。
+"""
+
+import warnings
+
+import pytest
+
+from daida_ai.lib.slide_spec import (
+    validate_slide_spec,
+    MAX_TITLE_LENGTH,
+    MAX_SUBTITLE_LENGTH,
+    MAX_BODY_ITEM_LENGTH,
+    MAX_NOTE_LENGTH,
+    MAX_HEADING_LENGTH,
+)
+
+
+def _spec(slides, **meta_overrides):
+    """テスト用の最小限スライド仕様を作成するヘルパー"""
+    meta = {"title": "テスト", "subtitle": "", "event": ""}
+    meta.update(meta_overrides)
+    return {"metadata": meta, "slides": slides}
+
+
+def _slide(layout, **kwargs):
+    """テスト用スライドを作成するヘルパー"""
+    s = {"layout": layout}
+    s.update(kwargs)
+    return s
+
+
+# ---------------------------------------------------------------------------
+# 1. レイアウト-フィールド整合性
+# ---------------------------------------------------------------------------
+class Testレイアウトフィールド整合性:
+    """各レイアウトに必須/不要なフィールドの検証"""
+
+    def test_two_contentにleftがないとValueError(self):
+        spec = _spec([_slide(
+            "two_content", title="テスト",
+            right={"heading": "右", "body": ["a"]},
+            note="ノート",
+        )])
+        with pytest.raises(ValueError, match="left.*required"):
+            validate_slide_spec(spec)
+
+    def test_two_contentにrightがないとValueError(self):
+        spec = _spec([_slide(
+            "two_content", title="テスト",
+            left={"heading": "左", "body": ["a"]},
+            note="ノート",
+        )])
+        with pytest.raises(ValueError, match="right.*required"):
+            validate_slide_spec(spec)
+
+    def test_two_contentにleftとright両方あれば通る(self):
+        spec = _spec([_slide(
+            "two_content", title="テスト",
+            left={"heading": "左", "body": ["a"]},
+            right={"heading": "右", "body": ["b"]},
+            note="ノート",
+        )])
+        result = validate_slide_spec(spec)
+        assert result.slides[0].left is not None
+
+    def test_title_and_contentにbodyがないとValueError(self):
+        spec = _spec([_slide(
+            "title_and_content", title="テスト", note="ノート",
+        )])
+        with pytest.raises(ValueError, match="body.*required"):
+            validate_slide_spec(spec)
+
+    def test_title_and_contentにbodyがあれば通る(self):
+        spec = _spec([_slide(
+            "title_and_content", title="テスト",
+            body=["項目1"], note="ノート",
+        )])
+        result = validate_slide_spec(spec)
+        assert result.slides[0].body == ["項目1"]
+
+    def test_title_slideにbodyを指定するとValueError(self):
+        spec = _spec([_slide(
+            "title_slide", title="テスト", body=["不要"],
+        )])
+        with pytest.raises(ValueError, match="body.*not supported"):
+            validate_slide_spec(spec)
+
+    def test_title_slideにleftを指定するとValueError(self):
+        spec = _spec([_slide(
+            "title_slide", title="テスト",
+            left={"heading": "左", "body": ["a"]},
+        )])
+        with pytest.raises(ValueError, match="left.*not supported"):
+            validate_slide_spec(spec)
+
+    def test_blankにbodyを指定するとValueError(self):
+        spec = _spec([_slide("blank", body=["不要"])])
+        with pytest.raises(ValueError, match="body.*not supported"):
+            validate_slide_spec(spec)
+
+    def test_section_headerにleftを指定するとValueError(self):
+        spec = _spec([_slide(
+            "section_header", title="セクション",
+            left={"heading": "左", "body": ["a"]},
+        )])
+        with pytest.raises(ValueError, match="left.*not supported"):
+            validate_slide_spec(spec)
+
+    def test_title_onlyにbodyを指定するとValueError(self):
+        spec = _spec([_slide(
+            "title_only", title="テスト", note="ノート",
+            body=["不要"],
+        )])
+        with pytest.raises(ValueError, match="body.*not supported"):
+            validate_slide_spec(spec)
+
+
+# ---------------------------------------------------------------------------
+# 2. 2カラム heading 長チェック
+# ---------------------------------------------------------------------------
+class Test2カラムheading長:
+    """TwoColumnContent.heading の文字数上限"""
+
+    def test_heading上限以内なら通る(self):
+        spec = _spec([_slide(
+            "two_content", title="テスト",
+            left={"heading": "あ" * MAX_HEADING_LENGTH, "body": ["a"]},
+            right={"heading": "い", "body": ["b"]},
+            note="ノート",
+        )])
+        result = validate_slide_spec(spec)
+        assert len(result.slides[0].left.heading) == MAX_HEADING_LENGTH
+
+    def test_heading上限超過でValueError(self):
+        spec = _spec([_slide(
+            "two_content", title="テスト",
+            left={"heading": "あ" * (MAX_HEADING_LENGTH + 1), "body": ["a"]},
+            right={"heading": "い", "body": ["b"]},
+            note="ノート",
+        )])
+        with pytest.raises(ValueError, match="heading.*exceeds"):
+            validate_slide_spec(spec)
+
+
+# ---------------------------------------------------------------------------
+# 3. ノート文字数上限
+# ---------------------------------------------------------------------------
+class Testノート長:
+    """note フィールドの文字数上限"""
+
+    def test_ノート上限以内なら通る(self):
+        spec = _spec([_slide(
+            "title_and_content", title="テスト",
+            body=["項目"], note="あ" * MAX_NOTE_LENGTH,
+        )])
+        # 長いノートは発話時間制限を超えるため緩和
+        result = validate_slide_spec(spec, max_talk_duration_sec=9999)
+        assert len(result.slides[0].note) == MAX_NOTE_LENGTH
+
+    def test_ノート上限超過でValueError(self):
+        spec = _spec([_slide(
+            "title_and_content", title="テスト",
+            body=["項目"], note="あ" * (MAX_NOTE_LENGTH + 1),
+        )])
+        with pytest.raises(ValueError, match="note.*exceeds"):
+            validate_slide_spec(spec)
+
+
+# ---------------------------------------------------------------------------
+# 4. 2カラム body 項目文字数チェック
+# ---------------------------------------------------------------------------
+class Test2カラムbody項目長:
+    """left.body / right.body 各項目の文字数上限"""
+
+    def test_2カラムbody項目が上限以内なら通る(self):
+        spec = _spec([_slide(
+            "two_content", title="テスト",
+            left={"heading": "左", "body": ["あ" * MAX_BODY_ITEM_LENGTH]},
+            right={"heading": "右", "body": ["い"]},
+            note="ノート",
+        )])
+        result = validate_slide_spec(spec)
+        assert len(result.slides[0].left.body[0]) == MAX_BODY_ITEM_LENGTH
+
+    def test_2カラムbody項目が上限超過でValueError(self):
+        spec = _spec([_slide(
+            "two_content", title="テスト",
+            left={"heading": "左", "body": ["あ" * (MAX_BODY_ITEM_LENGTH + 1)]},
+            right={"heading": "右", "body": ["い"]},
+            note="ノート",
+        )])
+        with pytest.raises(ValueError, match="body.*exceeds"):
+            validate_slide_spec(spec)
+
+    def test_right側のbody項目超過もValueError(self):
+        spec = _spec([_slide(
+            "two_content", title="テスト",
+            left={"heading": "左", "body": ["a"]},
+            right={"heading": "右", "body": ["い" * (MAX_BODY_ITEM_LENGTH + 1)]},
+            note="ノート",
+        )])
+        with pytest.raises(ValueError, match="body.*exceeds"):
+            validate_slide_spec(spec)
+
+
+# ---------------------------------------------------------------------------
+# 5. メタデータ subtitle/event 長チェック
+# ---------------------------------------------------------------------------
+class Testメタデータ長:
+    """metadata.subtitle / metadata.event の文字数上限"""
+
+    def test_メタデータsubtitle上限超過でValueError(self):
+        spec = _spec(
+            [_slide("title_slide", title="テスト")],
+            subtitle="あ" * (MAX_SUBTITLE_LENGTH + 1),
+        )
+        with pytest.raises(ValueError, match="metadata.subtitle.*exceeds"):
+            validate_slide_spec(spec)
+
+    def test_メタデータevent上限超過でValueError(self):
+        spec = _spec(
+            [_slide("title_slide", title="テスト")],
+            event="あ" * (MAX_SUBTITLE_LENGTH + 1),
+        )
+        with pytest.raises(ValueError, match="metadata.event.*exceeds"):
+            validate_slide_spec(spec)
+
+
+# ---------------------------------------------------------------------------
+# 6. image 空文字列チェック
+# ---------------------------------------------------------------------------
+class Testimage空文字列:
+    """image フィールドが空文字列の場合"""
+
+    def test_imageが空文字列でValueError(self):
+        spec = _spec([_slide(
+            "title_and_content", title="テスト",
+            body=["項目"], note="ノート", image="",
+        )])
+        with pytest.raises(ValueError, match="image.*empty"):
+            validate_slide_spec(spec)
+
+    def test_imageがNoneなら通る(self):
+        spec = _spec([_slide(
+            "title_and_content", title="テスト",
+            body=["項目"], note="ノート", image=None,
+        )])
+        result = validate_slide_spec(spec)
+        assert result.slides[0].image is None
+
+    def test_imageが有効な文字列なら通る(self):
+        spec = _spec([_slide(
+            "title_and_content", title="テスト",
+            body=["項目"], note="ノート", image="diagram.png",
+        )])
+        result = validate_slide_spec(spec)
+        assert result.slides[0].image == "diagram.png"
+
+
+# ---------------------------------------------------------------------------
+# 7. 先頭スライドのレイアウト推奨チェック（warning）
+# ---------------------------------------------------------------------------
+class Test先頭スライドレイアウト:
+    """先頭スライドが title_slide でない場合に warning"""
+
+    def test_先頭がtitle_slideならwarningなし(self):
+        spec = _spec([
+            _slide("title_slide", title="タイトル"),
+            _slide("title_and_content", title="内容", body=["a"], note="ノート"),
+        ])
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            validate_slide_spec(spec)
+            layout_warnings = [
+                x for x in w if "title_slide" in str(x.message)
+            ]
+            assert len(layout_warnings) == 0
+
+    def test_先頭がtitle_slideでないとwarning(self):
+        spec = _spec([
+            _slide("title_and_content", title="いきなり内容", body=["a"], note="ノート"),
+        ])
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            validate_slide_spec(spec)
+            layout_warnings = [
+                x for x in w if "title_slide" in str(x.message)
+            ]
+            assert len(layout_warnings) == 1


### PR DESCRIPTION
## Summary
LLMがJSON生成時にフィールドを取り違えた場合、バリデーション段階で明確なエラーを返す。

1. レイアウト-フィールド整合性: `two_content`にleft/right必須、`title_slide`にbody禁止 等
2. 2カラムheading文字数上限（100字）
3. ノート文字数上限（10000字）
4. 2カラムbody項目文字数チェック
5. メタデータsubtitle/event文字数上限
6. image空文字列チェック
7. 先頭スライドがtitle_slideでない場合にwarning

## Test plan
- [x] 24テスト追加（レイアウト整合性11 + heading2 + note2 + body3 + meta2 + image3 + warning2）
- [x] 全501 passed, 2 skipped
- [x] coderabbit: No findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)